### PR TITLE
Add audio player

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -477,10 +477,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -772,12 +820,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -832,9 +896,13 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -2160,6 +2228,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3364,6 +3452,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3376,6 +3487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3451,12 +3563,17 @@ name = "tts-helper"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bytes",
+ "crossbeam",
+ "futures",
  "reqwest",
  "rodio",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "thiserror",
+ "tower",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,13 @@ serde_json = "1.0"
 rodio = "0.17.1"
 reqwest = "0.11.16"
 anyhow = "1.0.70"
+bytes = "1"
+thiserror = "1"
+crossbeam = "0.8"
+
+# Futures
+tower = { version = "0.4", features = ["buffer", "limit", "util"] }
+futures = "0.3"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/src-tauri/src/api_result.rs
+++ b/src-tauri/src/api_result.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize };
+use serde::Serialize;
 use std::error::Error;
 
 #[derive(Clone, Debug, Serialize)]

--- a/src-tauri/src/audio_player.rs
+++ b/src-tauri/src/audio_player.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+
+use tauri::async_runtime::Mutex;
+use tower::{util::BoxService, BoxError, Service, ServiceBuilder, ServiceExt};
+
+use crate::{
+    api_result::FormattedError,
+    services::{AudioRequest, AudioQueueService, CreateAudioDeviceError, DownloadAudioLayer},
+};
+
+/// The audio player.
+pub struct AudioPlayer {
+    service: Arc<Mutex<BoxService<AudioRequest, (), FormattedError>>>,
+}
+
+impl AudioPlayer {
+    /// Creates a new [`AudioPlayer`] with the default output device.
+    pub fn new_default() -> Result<Self, CreateAudioDeviceError> {
+        let service = ServiceBuilder::new()
+            .map_err(|err: BoxError| FormattedError::from(&*err))
+            .layer(DownloadAudioLayer::default())
+            .service(AudioQueueService::new_default()?)
+            .boxed();
+
+        Ok(Self {
+            service: Arc::new(Mutex::new(service)),
+        })
+    }
+
+    /// Plays the audio at the given URL.
+    pub async fn play_tts(&self, message: String) -> Result<(), FormattedError> {
+        let mut service = self.service.lock().await;
+        service.ready().await?;
+        let fut = service.call(AudioRequest { message });
+        drop(service);
+
+        fut.await?;
+
+        Ok(())
+    }
+}

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -1,0 +1,5 @@
+mod audio_service;
+mod download_audio;
+
+pub use audio_service::*;
+pub use download_audio::*;

--- a/src-tauri/src/services/audio_service.rs
+++ b/src-tauri/src/services/audio_service.rs
@@ -1,0 +1,117 @@
+use std::{
+    io::Cursor,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use bytes::Bytes;
+use crossbeam::channel::{Receiver, Sender};
+use futures::{future::BoxFuture, FutureExt};
+use rodio::{
+    decoder::DecoderError, Decoder, OutputStream, OutputStreamHandle, PlayError, Sink, StreamError,
+};
+use thiserror::Error;
+use tower::{BoxError, Service};
+
+/// Service for playing audio.
+pub struct AudioQueueService {
+    event_tx: Sender<AudioEvent>,
+}
+
+impl AudioQueueService {
+    /// Creates a new [`AudioService`] with the default output device.
+    pub fn new_default() -> Result<Self, CreateAudioDeviceError> {
+        let (event_tx, event_rx) = crossbeam::channel::unbounded();
+        let (sink_tx, sink_rx) = crossbeam::channel::unbounded();
+        std::thread::spawn(move || play_audio(event_rx, sink_tx));
+
+        // Get the audio sink back
+        let Ok(sink) = sink_rx.recv() else {
+            return Err(CreateAudioDeviceError::Stream(StreamError::NoDevice));
+        };
+        let _ = sink?;
+
+        Ok(Self { event_tx })
+    }
+}
+
+impl Service<Bytes> for AudioQueueService {
+    type Response = ();
+    type Error = BoxError;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, data: Bytes) -> Self::Future {
+        let _ = self.event_tx.send(AudioEvent::Play(data));
+
+        std::future::ready(Ok(())).boxed()
+    }
+}
+
+fn create_sink() -> Result<(OutputStream, OutputStreamHandle, Arc<Sink>), CreateAudioDeviceError> {
+    let (stream, stream_handle) = OutputStream::try_default()?;
+    let sink = Sink::try_new(&stream_handle)?;
+    Ok((stream, stream_handle, Arc::new(sink)))
+}
+
+fn play_audio(
+    event_rx: Receiver<AudioEvent>,
+    sink_tx: Sender<Result<Arc<Sink>, CreateAudioDeviceError>>,
+) {
+    // Create output device
+    let (_stream, _stream_handle, sink) = match create_sink() {
+        Ok(res) => res,
+        Err(error) => {
+            // Failed to create sink
+            let _ = sink_tx.send(Err(error));
+            return;
+        }
+    };
+    let _ = sink_tx.send(Ok(sink.clone()));
+
+    // Handle audio events
+    for event in event_rx {
+        match event {
+            AudioEvent::Play(data) => {
+                println!("received audio");
+
+                // Decode the source data
+                let source = match Decoder::new(Cursor::new(data)) {
+                    Ok(decoder) => decoder,
+                    Err(error) => {
+                        println!("failed to decode audio: {error}");
+                        continue;
+                    }
+                };
+
+                // Enqueue the audio
+                println!("enqueuing audio");
+                sink.append(source);
+            }
+        }
+    }
+
+    println!("stopping audio");
+    sink.stop();
+}
+
+enum AudioEvent {
+    Play(Bytes),
+}
+
+#[derive(Debug, Error)]
+pub enum CreateAudioDeviceError {
+    #[error("audio stream could not be opened")]
+    Stream(#[from] StreamError),
+    #[error("audio sink could not be created")]
+    Sink(#[from] PlayError),
+}
+
+#[derive(Debug, Error)]
+pub enum PlayAudioError {
+    #[error("could not decode data")]
+    Decode(#[from] DecoderError),
+}

--- a/src-tauri/src/services/download_audio.rs
+++ b/src-tauri/src/services/download_audio.rs
@@ -1,0 +1,78 @@
+use std::{
+    future::Future,
+    pin::pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use bytes::Bytes;
+use futures::{future::BoxFuture, FutureExt};
+use reqwest::Client;
+use tauri::async_runtime::Mutex;
+use tower::{BoxError, Layer, Service};
+
+#[derive(Clone, Default)]
+pub struct DownloadAudioLayer {
+    client: Client,
+}
+
+impl<S> Layer<S> for DownloadAudioLayer {
+    type Service = DownloadAudioService<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        DownloadAudioService {
+            next: Arc::new(Mutex::new(service)),
+            client: self.client.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DownloadAudioService<S> {
+    next: Arc<Mutex<S>>, // TODO: maybe don't use mutex
+    client: Client,
+}
+
+impl<S> Service<AudioRequest> for DownloadAudioService<S>
+where
+    S: Service<Bytes, Error = BoxError> + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let fut = pin!(self.next.lock());
+        let Poll::Ready(mut next) = fut.poll(cx) else {
+            return Poll::Pending;
+        };
+
+        next.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: AudioRequest) -> Self::Future {
+        let client = self.client.clone();
+        let next = self.next.clone();
+        async move {
+            let bytes = fetch_audio(req, client).await?;
+            next.lock().await.call(bytes).await
+        }
+        .boxed()
+    }
+}
+
+/// A request to play some audio.
+pub struct AudioRequest {
+    pub message: String,
+}
+
+async fn fetch_audio(req: AudioRequest, client: Client) -> Result<Bytes, BoxError> {
+    let response = client
+        .get("https://api.streamelements.com/kappa/v2/speech")
+        .query(&[("voice", "Brian"), ("text", &req.message)])
+        .send()
+        .await?;
+    let bytes = response.bytes().await?;
+    Ok(bytes)
+}


### PR DESCRIPTION
Adds an audio player. This does not do any kind of backbuffering or anything but does queue up audio to play. We can add support for applying backpressure when too many audio requests come in pretty easily, but I wanted to get the simple case merged first.