### PR TITLE
Setup tracing

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3574,6 +3574,8 @@ dependencies = [
  "tauri-build",
  "thiserror",
  "tower",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,10 @@ crossbeam = "0.8"
 tower = { version = "0.4", features = ["buffer", "limit", "util"] }
 futures = "0.3"
 
+# Tracing
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem
 # DO NOT REMOVE!!

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,6 +10,7 @@ use audio_player::AudioPlayer;
 mod api_result;
 use api_result::ApiResult;
 use tauri::State;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
 
 // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
 #[tauri::command]
@@ -24,6 +25,15 @@ async fn play_tts(_url: String, audio_player: State<'_, AudioPlayer>) -> ApiResu
 }
 
 fn main() -> anyhow::Result<()> {
+    Registry::default()
+        .with(if cfg!(debug_assertions) {
+            EnvFilter::new("info,tts_helper=trace")
+        } else {
+            EnvFilter::new("info")
+        })
+        .with(tracing_subscriber::fmt::layer().compact())
+        .try_init()?;
+
     let audio_player = AudioPlayer::new_default()?;
 
     tauri::Builder::default()


### PR DESCRIPTION
Setup `tracing` to get and show traces from `tts_helper` and its dependencies.

We can also use `EnvFilter::from_default_env()` and read the filter from the `RUST_LOG` environment variable (or specify our own variable name if we want), but this PR just does "info for everything and trace for us" on debug and "info for everything" on release.