### PR TITLE
Allow requests to be skipped

### DIFF
--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,5 +1,7 @@
 mod audio_request;
+mod audio_state;
 mod playing_audio;
 
 pub use audio_request::*;
+pub use audio_state::*;
 pub use playing_audio::*;

--- a/src-tauri/src/models/audio_state.rs
+++ b/src-tauri/src/models/audio_state.rs
@@ -1,0 +1,11 @@
+use serde::Deserialize;
+
+/// Sets the state of an audio source.
+#[derive(Clone, Debug, Deserialize)]
+pub struct SetAudioState {
+    /// The ID of the audio source.
+    pub id: u32,
+    /// Whether the audio source is skipped.
+    #[serde(default)]
+    pub skip: Option<bool>,
+}

--- a/src-tauri/src/services/now_playing.rs
+++ b/src-tauri/src/services/now_playing.rs
@@ -3,30 +3,55 @@ use std::sync::{
     Mutex,
 };
 
-use crate::models::{AudioRequest, PlayingAudio};
+use crate::models::{AudioRequest, PlayingAudio, SetAudioState};
+
+use super::Controller;
 
 #[derive(Debug, Default)]
 pub struct NowPlaying {
-    requests: Mutex<Vec<PlayingAudio>>,
+    playing: Mutex<Vec<(PlayingAudio, Controller)>>,
     next_id: AtomicU32,
 }
 
 impl NowPlaying {
     /// Adds a new request to the queue.
-    pub fn add(&self, request: AudioRequest) -> u32 {
+    pub fn add(&self, request: AudioRequest, controller: Controller) -> u32 {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
-        self.requests.lock().unwrap().push(PlayingAudio { id, request });
+        self.playing
+            .lock()
+            .unwrap()
+            .push((PlayingAudio { id, request }, controller));
         id
     }
 
     /// Removes a request from the queue.
     pub fn remove(&self, id: u32) {
-        let mut requests = self.requests.lock().unwrap();
-        requests.retain(|audio| audio.id != id);
+        let mut requests = self.playing.lock().unwrap();
+        requests.retain(|(audio, _)| audio.id != id);
     }
 
     /// Gets the current queue.
     pub fn get_playing(&self) -> Vec<PlayingAudio> {
-        self.requests.lock().unwrap().clone()
+        self.playing
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(audio, _)| audio)
+            .cloned()
+            .collect()
+    }
+
+    /// Sets the state of an audio request.
+    pub fn merge_state(&self, set_state: SetAudioState) -> bool {
+        let mut playing = self.playing.lock().unwrap();
+        let Some((_, controller)) = playing.iter_mut().find(|(audio, _)| audio.id == set_state.id) else {
+            return false;
+        };
+
+        if set_state.skip == Some(true) {
+            controller.skip();
+        }
+
+        true
     }
 }

--- a/src-tauri/src/services/player.rs
+++ b/src-tauri/src/services/player.rs
@@ -1,3 +1,7 @@
+mod controllable;
+mod controller;
 mod player;
 
+pub use controllable::*;
+pub use controller::*;
 pub use player::*;

--- a/src-tauri/src/services/player/controllable.rs
+++ b/src-tauri/src/services/player/controllable.rs
@@ -1,0 +1,67 @@
+use std::time::Duration;
+
+use rodio::{Sample, Source};
+
+use super::Controller;
+
+#[derive(Debug)]
+pub struct Controllable<S> {
+    inner: S,
+    controller: Controller,
+}
+
+impl<S> Controllable<S> {
+    /// Create a new controllable [`Source`].
+    pub fn new(inner: S, controller: Controller) -> Self {
+        Self { inner, controller }
+    }
+}
+
+impl<S> Source for Controllable<S>
+where
+    S: Source + Iterator,
+    S::Item: Sample,
+{
+    fn current_frame_len(&self) -> Option<usize> {
+        if self.controller.is_skipped() {
+            return Some(0);
+        }
+
+        self.inner.current_frame_len()
+    }
+
+    fn channels(&self) -> u16 {
+        self.inner.channels()
+    }
+
+    fn sample_rate(&self) -> u32 {
+        self.inner.sample_rate()
+    }
+
+    fn total_duration(&self) -> Option<Duration> {
+        if self.controller.is_skipped() {
+            return Some(Duration::ZERO);
+        }
+
+        self.inner.total_duration()
+    }
+}
+
+impl<S> Iterator for Controllable<S>
+where
+    S: Iterator,
+{
+    type Item = S::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.controller.is_skipped() {
+            return None;
+        }
+
+        self.inner.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}

--- a/src-tauri/src/services/player/controller.rs
+++ b/src-tauri/src/services/player/controller.rs
@@ -1,0 +1,28 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+/// A controller for an audio source. This can be cloned to create multiple controllers for the same
+/// audio source.
+#[derive(Clone, Debug, Default)]
+pub struct Controller {
+    state: Arc<ControllerState>,
+}
+
+impl Controller {
+    /// Skip this audio source.
+    pub fn skip(&self) {
+        self.state.skipped.store(true, Ordering::Relaxed);
+    }
+
+    /// Check if this audio source is skipped.
+    pub fn is_skipped(&self) -> bool {
+        self.state.skipped.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Debug, Default)]
+struct ControllerState {
+    skipped: AtomicBool,
+}

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -20,13 +20,6 @@ export class HomeComponent {
     const { value } = this.ttsControl;
     this.ttsControl.setValue('');
 
-    this.history.push({
-      createdAt: new Date(),
-      source: 'youtube',
-      text: value ?? '[No TTS text found]',
-      username: 'Panku',
-    });
-
     invoke('play_tts', {
       request: {
         url: 'https://api.streamelements.com/kappa/v2/speech',
@@ -35,6 +28,19 @@ export class HomeComponent {
           ['text', value],
         ],
       },
+    }).then(id => {
+      if (typeof id != 'number') {
+        throw new Error(`Unexpected response type: ${typeof id}`);
+      }
+
+      this.history.push({
+        id,
+        createdAt: new Date(),
+        source: 'youtube',
+        text: value ?? '[No TTS text found]',
+        username: 'Panku',
+        skipped: false,
+      });
     }).catch((e) => {
       console.error(`Error invoking play_tts: ${e}`);
 

--- a/src/app/shared/components/history/history-item/history-item.component.html
+++ b/src/app/shared/components/history/history-item/history-item.component.html
@@ -4,5 +4,7 @@
     <span class="time">{{ audit.createdAt | date : 'medium' }}</span>
   </div>
   <hr />
+  <span class="text" *ngIf="audit.skipped">(Skipped)</span>
   <span class="text">{{ audit.text }}</span>
+  <button (click)="skip()">Skip</button>
 </div>

--- a/src/app/shared/components/history/history-item/history-item.component.ts
+++ b/src/app/shared/components/history/history-item/history-item.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { AuditItem } from './history-item.interface';
+import { invoke } from '@tauri-apps/api';
 
 @Component({
   selector: 'app-history-item',
@@ -11,5 +12,14 @@ export class HistoryItemComponent {
 
   get svg() {
     return `assets/${this.audit.source.toLowerCase()}.svg`;
+  }
+
+  skip() {
+    invoke('set_audio_state', {
+      state: {
+        id: this.audit.id,
+        skip: true,
+      }
+    }).then(() => this.audit.skipped = true);
   }
 }

--- a/src/app/shared/components/history/history-item/history-item.interface.ts
+++ b/src/app/shared/components/history/history-item/history-item.interface.ts
@@ -1,6 +1,8 @@
 export interface AuditItem {
+  id: number;
   username: string;
   text: string;
   source: 'youtube' | 'twitch';
   createdAt: Date;
+  skipped: boolean;
 }


### PR DESCRIPTION
Adds a simple, ugly 'Skip' button to each history item to allow them to be skipped. We can style that later, just wanted to get the functionality there.

Also updates the backend of course. We'll be able to set other properties of the audio as well later on like speed, amplitude, etc.