### PR TITLE
Emit event when audio completes

### DIFF
--- a/src-tauri/src/services/now_playing.rs
+++ b/src-tauri/src/services/now_playing.rs
@@ -36,6 +36,7 @@ impl NowPlaying {
             .lock()
             .unwrap()
             .iter()
+            .filter(|(_, controller)| !controller.is_skipped())
             .map(|(audio, _)| audio)
             .cloned()
             .collect()


### PR DESCRIPTION
Backend now emits an `audio-done` event when an audio clip finishes playing. This PR also updates the `get_now_playing` command to only return audio that hasn't been skipped.