### PR TITLE
Add http server for capturing tokens

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -67,6 +67,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "async-trait"
+version = "0.1.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
+
+[[package]]
 name = "atk"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +106,54 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b32c5ea3aabaf4deb5f5ced2d688ec0844c881c9e6c696a8b769a05fc691e62"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa 1.0.6",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -1680,6 +1739,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2205,6 +2270,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2973,6 +3058,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "system-deps"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3412,6 +3503,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3499,6 +3611,7 @@ name = "tts-helper"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "axum",
  "bytes",
  "crossbeam",
  "reqwest",
@@ -3508,6 +3621,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "thiserror",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,14 @@ bytes = "1"
 thiserror = "1"
 crossbeam = "0.8"
 
+# Web server
+tokio = { version = "1", features = ["rt"] }
+axum = { version = "0.6", default-features = false, features = [
+    "http1",
+    "tokio",
+    "tracing",
+] }
+
 # Tracing
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use models::{PlayingAudio, SetAudioState};
-use services::{AudioPlayer, Controller, NowPlaying};
+use services::{run_auth_server, AudioPlayer, Controller, NowPlaying};
 use tracing::trace;
 
 use crate::{api_result::ApiResult, models::AudioRequest};
@@ -69,6 +69,13 @@ fn main() -> anyhow::Result<()> {
     tauri::Builder::default()
         .manage(audio_player)
         .manage(Arc::new(NowPlaying::default()))
+        .setup(|app| {
+            // Run auth server
+            let handle = app.handle();
+            std::thread::spawn(move || run_auth_server(handle));
+
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             greet,
             play_tts,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,7 +1,9 @@
 mod audio_request;
 mod audio_state;
 mod playing_audio;
+mod auth_event;
 
 pub use audio_request::*;
 pub use audio_state::*;
 pub use playing_audio::*;
+pub use auth_event::*;

--- a/src-tauri/src/models/auth_event.rs
+++ b/src-tauri/src/models/auth_event.rs
@@ -1,0 +1,10 @@
+use serde::Serialize;
+
+/// The event sent when the user authenticates with a provider.
+#[derive(Clone, Debug, Serialize)]
+pub struct AuthEvent {
+    /// The provider that the user authenticated with.
+    pub provider: String,
+    /// The token that was returned by the provider.
+    pub token: String,
+}

--- a/src-tauri/src/services.rs
+++ b/src-tauri/src/services.rs
@@ -1,5 +1,7 @@
 mod now_playing;
+mod oauth_listener;
 mod player;
 
 pub use now_playing::*;
+pub use oauth_listener::*;
 pub use player::*;

--- a/src-tauri/src/services/oauth_listener.rs
+++ b/src-tauri/src/services/oauth_listener.rs
@@ -1,0 +1,78 @@
+use std::net::Ipv4Addr;
+
+use axum::{extract::Path, response::Html, routing::get, Extension, Router, Server};
+use tauri::{AppHandle, Manager};
+use tokio::runtime::Builder;
+use tracing::{debug, error, instrument};
+
+use crate::models::AuthEvent;
+
+/// Runs the auth server, which listens on `http://localhost:12583/auth`. It expects to receive the
+/// access token as a hash fragment in the URL, and then sends it to the app via a global event.
+#[instrument(skip_all)]
+pub fn run_auth_server(app: AppHandle) {
+    fn run_server_inner(app: AppHandle) -> anyhow::Result<()> {
+        let rt = Builder::new_current_thread().enable_all().build()?;
+        rt.block_on(listen(app))
+    }
+
+    if let Err(error) = run_server_inner(app) {
+        error!(?error, "error while running oauth server: {error}");
+    }
+}
+
+async fn listen(app: AppHandle) -> anyhow::Result<()> {
+    // Create app
+    let app = Router::new()
+        .route("/auth/:provider", get(auth_get).post(auth_post))
+        .layer(Extension(app));
+
+    // Run server
+    const PORT: u16 = 12583;
+    Server::bind(&(Ipv4Addr::UNSPECIFIED, PORT).into())
+        .serve(app.into_make_service())
+        .await?;
+
+    Ok(())
+}
+
+async fn auth_get() -> Html<&'static str> {
+    const BODY: &'static str = &r#"
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <title>Authenticating</title>
+            </head>
+            <body>
+                <script>
+                    if (window.location.hash) {
+                        const token = window.location.hash.split("=")[1];
+                        fetch(window.location.href, {
+                            method: "POST",
+                            body: token,
+                        }).then(() => {
+                            document.getElementById("status").innerText = "Authenticated!";
+                        }).catch((err) => {
+                            console.error(err);
+                            document.getElementById("status").innerText = "Failed to authenticate. Check the console for more details.";
+                        });
+                    } else {
+                        console.error("No token found in URL");
+                        document.getElementById("status").innerText = "Failed to authenticate. Check the console for more details.";
+                    }
+                </script>
+                <p id="status">Authenticating...</p>
+            </body>
+        </html>
+    "#;
+    Html(BODY)
+}
+
+async fn auth_post(
+    Path(provider): Path<String>,
+    Extension(app): Extension<AppHandle>,
+    token: String,
+) {
+    debug!(provider, "got auth token");
+    drop(app.emit_all("access-token", AuthEvent { provider, token }));
+}


### PR DESCRIPTION
Adds a http server that listens for auth tokens and completes the oauth flow for users. This should allow us to capture access tokens generated from twitch's oauth flow, for example. The server listens for `GET http://localhost:12583/auth/:provider#access_token=...`, where `:provider` is the provider name. It then sends the token via a global app event to the frontend along with which provider was authenticated.