### PR TITLE
Add pause/resume to audio queue

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -41,8 +41,16 @@ async fn play_tts(
             now_playing.remove(id)
         }
     };
-    audio_player.play_tts(request, on_start, on_finish, controller).await?;
+    audio_player
+        .play_tts(request, on_start, on_finish, controller)
+        .await?;
     Ok(id)
+}
+
+#[tauri::command]
+fn set_tts_paused(paused: bool, audio_player: State<'_, AudioPlayer>) -> ApiResult<()> {
+    audio_player.set_paused(paused);
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -88,6 +88,7 @@ fn main() -> anyhow::Result<()> {
         })
         .invoke_handler(tauri::generate_handler![
             play_tts,
+            set_tts_paused,
             get_now_playing,
             set_audio_state,
         ])


### PR DESCRIPTION
Adds the ability to pause/resume the audio queue. Currently playing sources will continue to play when paused, but no new items will play.