### PR TITLE
chore: move constructor DI's to use inject()

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -22,7 +22,7 @@
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:browser",
+          "builder": "@angular-devkit/build-angular:browser-esbuild",
           "options": {
             "outputPath": "dist/tts-helper",
             "index": "src/index.html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tts-helper",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "author": {
     "email": "dylanwarren19@gmail.com",
     "name": "Dylan Warren",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "TTS Helper",
-    "version": "1.3.9"
+    "version": "1.3.10"
   },
   "tauri": {
     "allowlist": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { TwitchPubSub } from './shared/services/twitch-pubsub';
 import { StorageService } from './shared/services/storage.service';
 import { Store } from '@ngrx/store';
@@ -40,28 +40,28 @@ import { VStreamPubSubService } from './shared/services/vstream-pubsub.service';
   imports: [NavComponent, RouterOutlet],
 })
 export class AppComponent {
+  private readonly store = inject(Store);
+  private readonly azureService = inject(AzureSttService);
+  private readonly elevenLabsService = inject(ElevenLabsService);
+  private readonly configService = inject(ConfigService);
+  private readonly openAIService = inject(OpenAIService);
+  private readonly obsSocketService = inject(ObsWebSocketService);
+  private readonly streamDeckSocketService = inject(StreamDeckWebSocketService);
+  private readonly playbackService = inject(PlaybackService);
+  private readonly storageService = inject(StorageService);
+  private readonly twitchPubSub = inject(TwitchPubSub);
+  private readonly twitchService = inject(TwitchService);
+  private readonly vtubeStudioService = inject(VTubeStudioService);
+  private readonly vstreamService = inject(VStreamService);
+  private readonly vstreamPubSub = inject(VStreamPubSubService);
+
   private readonly settingsLocation = '.settings.json';
 
   /**
    * @TODO - Figure out a better way to have the service come alive that isn't
    * just injecting it into the root of the app.
    */
-  constructor(
-    private readonly store: Store,
-    private readonly azureService: AzureSttService,
-    private readonly elevenLabsService: ElevenLabsService,
-    private readonly configService: ConfigService,
-    private readonly openAIService: OpenAIService,
-    private readonly obsSocketService: ObsWebSocketService,
-    private readonly streamDeckSocketService: StreamDeckWebSocketService,
-    private readonly playbackService: PlaybackService,
-    private readonly storageService: StorageService,
-    private readonly twitchPubSub: TwitchPubSub,
-    private readonly twitchService: TwitchService,
-    private readonly vtubeStudioService: VTubeStudioService,
-    private readonly vstreamService: VStreamService,
-    private readonly vstreamPubSub: VStreamPubSubService,
-  ) {
+  constructor() {
     combineLatest([
       this.storageService.getFromStore<ConfigState>(this.settingsLocation, 'config'),
       this.storageService.getFromStore<OpenAIState>(this.settingsLocation, 'openai'),

--- a/src/app/pages/azure-stt/azure-stt.component.ts
+++ b/src/app/pages/azure-stt/azure-stt.component.ts
@@ -25,7 +25,7 @@ export class AzureSttComponent {
   readonly regions = azureTts.regions;
   readonly languages = azureTts.languages;
 
-  azureSettings = new FormGroup({
+  readonly azureSettings = new FormGroup({
     enabled: new FormControl(false, { nonNullable: true }),
     subscriptionKey: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
     region: new FormControl('', { nonNullable: true, validators: [Validators.required] }),

--- a/src/app/pages/azure-stt/azure-stt.component.ts
+++ b/src/app/pages/azure-stt/azure-stt.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener } from '@angular/core';
+import { Component, HostListener, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { LabelBlockComponent } from '../../shared/components/input-block/label-block.component';
@@ -20,8 +20,10 @@ import { RouterLink } from '@angular/router';
   styleUrls: ['./azure-stt.component.scss'],
 })
 export class AzureSttComponent {
-  regions = azureTts.regions;
-  languages = azureTts.languages;
+  private readonly azureService = inject(AzureSttService);
+
+  readonly regions = azureTts.regions;
+  readonly languages = azureTts.languages;
 
   azureSettings = new FormGroup({
     enabled: new FormControl(false, { nonNullable: true }),
@@ -60,7 +62,7 @@ export class AzureSttComponent {
     this.hotkey = (modifiers.length ? modifiers.join('+') + '+' : '') + key;
   }
 
-  constructor(private readonly azureService: AzureSttService) {
+  constructor() {
     this.azureSettings.valueChanges
       .pipe(takeUntilDestroyed())
       .subscribe(settings => {

--- a/src/app/pages/chat-gpt/chat-gpt.component.ts
+++ b/src/app/pages/chat-gpt/chat-gpt.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { InputComponent } from '../../shared/components/input/input.component';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -28,9 +28,11 @@ export interface GptPersonalityFormGroup {
   styleUrls: ['./chat-gpt.component.scss'],
 })
 export class ChatGptComponent {
-  charLimit = new FormControl(300, { nonNullable: true, validators: [Validators.min(0)] });
+  private readonly openAIService = inject(OpenAIService);
 
-  settingsGroup = new FormGroup({
+  readonly charLimit = new FormControl(300, { nonNullable: true, validators: [Validators.min(0)] });
+
+  readonly settingsGroup = new FormGroup({
     apiToken: new FormControl('', { nonNullable: true }),
     enabled: new FormControl(false, { nonNullable: true }),
     historyLimit: new FormControl(0, { nonNullable: true, validators: [Validators.min(0), Validators.max(20)] }),
@@ -44,7 +46,7 @@ export class ChatGptComponent {
    * These are to make the ChatGPT model a little more personal.
    * These are all for the { "role": "system" } content messages when sending to OpenAI.
    */
-  personalityGroup = new FormGroup<GptPersonalityFormGroup>({
+  readonly personalityGroup = new FormGroup<GptPersonalityFormGroup>({
     streamersIdentity: new FormControl('', { nonNullable: true }),
     streamerModelRelation: new FormControl('', { nonNullable: true }),
     streamersThoughtsOnModel: new FormControl('', { nonNullable: true }),
@@ -53,7 +55,7 @@ export class ChatGptComponent {
     modelsBackground: new FormControl('', { nonNullable: true }),
   });
 
-  constructor(private readonly openAIService: OpenAIService) {
+  constructor() {
     this.openAIService.personality$
       .pipe(takeUntilDestroyed(), take(1))
       .subscribe(personality => this.personalityGroup.setValue(personality, { emitEvent: false }));

--- a/src/app/pages/chat-settings/chat-settings.component.ts
+++ b/src/app/pages/chat-settings/chat-settings.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { InputComponent } from '../../shared/components/input/input.component';
 import { UserPermsComponent } from './user-perms/user-perms.component';
@@ -30,6 +30,8 @@ export interface ChatSettingsFormGroup {
   styleUrls: ['./chat-settings.component.scss'],
 })
 export class ChatSettingsComponent {
+  private readonly configService = inject(ConfigService);
+  private readonly openAIService = inject(OpenAIService);
 
   generalChat = new FormGroup<ChatSettingsFormGroup>({
     command: new FormControl('', { nonNullable: true }),
@@ -57,7 +59,7 @@ export class ChatSettingsComponent {
     payingMembers: new FormControl(false, { nonNullable: true }),
   });
 
-  constructor(private readonly configService: ConfigService, private readonly openAIService: OpenAIService) {
+  constructor() {
     this.openAIService.chatSettings$
       .pipe(takeUntilDestroyed())
       .subscribe(chatSettings => {

--- a/src/app/pages/chat-settings/chat-settings.component.ts
+++ b/src/app/pages/chat-settings/chat-settings.component.ts
@@ -33,27 +33,27 @@ export class ChatSettingsComponent {
   private readonly configService = inject(ConfigService);
   private readonly openAIService = inject(OpenAIService);
 
-  generalChat = new FormGroup<ChatSettingsFormGroup>({
+  readonly generalChat = new FormGroup<ChatSettingsFormGroup>({
     command: new FormControl('', { nonNullable: true }),
     cooldown: new FormControl(0, { nonNullable: true }),
     enabled: new FormControl(false, { nonNullable: true }),
     charLimit: new FormControl(100, { nonNullable: true, validators: [Validators.min(0)] }),
   });
 
-  generalPermissions = new FormGroup<ChatPermissionsFormGroup>({
+  readonly generalPermissions = new FormGroup<ChatPermissionsFormGroup>({
     allUsers: new FormControl(false, { nonNullable: true }),
     mods: new FormControl(false, { nonNullable: true }),
     payingMembers: new FormControl(false, { nonNullable: true }),
   });
 
-  gptChat = new FormGroup<ChatSettingsFormGroup>({
+  readonly gptChat = new FormGroup<ChatSettingsFormGroup>({
     command: new FormControl('', { nonNullable: true }),
     cooldown: new FormControl(0, { nonNullable: true }),
     enabled: new FormControl(false, { nonNullable: true }),
     charLimit: new FormControl(999, { nonNullable: true, validators: [Validators.min(0)] }),
   });
 
-  gptPermissions = new FormGroup<ChatPermissionsFormGroup>({
+  readonly gptPermissions = new FormGroup<ChatPermissionsFormGroup>({
     allUsers: new FormControl(false, { nonNullable: true }),
     mods: new FormControl(false, { nonNullable: true }),
     payingMembers: new FormControl(false, { nonNullable: true }),

--- a/src/app/pages/history/history.component.ts
+++ b/src/app/pages/history/history.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ButtonComponent } from '../../shared/components/button/button.component';
 import { LogService } from '../../shared/services/logs.service';
 import { PlaybackService } from '../../shared/services/playback.service';
@@ -14,10 +14,10 @@ import { AudioStatus } from '../../shared/state/audio/audio.feature';
   imports: [ButtonComponent, AudioListComponent, AsyncPipe],
 })
 export class HistoryComponent {
+  private readonly logService = inject(LogService);
+  private readonly playbackService = inject(PlaybackService);
+  protected readonly isPaused$ = this.playbackService.isPaused$;
   protected readonly AudioStatus = AudioStatus;
-  isPaused$ = this.playbackService.isPaused$;
-
-  constructor(private readonly logService: LogService, private readonly playbackService: PlaybackService) {}
 
   togglePause() {
     this.playbackService.togglePause()

--- a/src/app/pages/live-queue/live-queue.component.ts
+++ b/src/app/pages/live-queue/live-queue.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AudioListComponent } from '../../shared/components/audio-list/audio-list.component';
 import { ButtonComponent } from '../../shared/components/button/button.component';
@@ -11,13 +11,14 @@ import { AudioStatus } from '../../shared/state/audio/audio.feature';
   standalone: true,
   imports: [CommonModule, AudioListComponent, ButtonComponent],
   templateUrl: './live-queue.component.html',
-  styleUrls: ['./live-queue.component.scss']
+  styleUrls: ['./live-queue.component.scss'],
 })
 export class LiveQueueComponent {
-  protected readonly AudioStatus = AudioStatus;
-  isPaused$ = this.playbackService.isPaused$;
+  private readonly logService = inject(LogService);
+  private readonly playbackService = inject(PlaybackService);
 
-  constructor(private readonly logService: LogService, private readonly playbackService: PlaybackService) {}
+  protected readonly AudioStatus = AudioStatus;
+  protected readonly isPaused$ = this.playbackService.isPaused$;
 
   togglePause() {
     this.playbackService.togglePause()
@@ -27,4 +28,4 @@ export class LiveQueueComponent {
   }
 }
 
-export default LiveQueueComponent
+export default LiveQueueComponent;

--- a/src/app/pages/moderation/moderation.component.ts
+++ b/src/app/pages/moderation/moderation.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { debounceTime } from 'rxjs';
 import { ConfigService } from 'src/app/shared/services/config.service';
@@ -16,11 +16,14 @@ import { LabelBlockComponent } from '../../shared/components/input-block/label-b
   imports: [FormsModule, ReactiveFormsModule, NgClass, ToggleComponent, LabelBlockComponent],
 })
 export class ModerationComponent {
-  // Just to prevent streamers from showing bad words on stream
-  hideBannedWords = new FormControl(true, { nonNullable: true });
-  bannedWords = new FormControl('', { nonNullable: true });
+  private readonly configService = inject(ConfigService);
+  private readonly logService = inject(LogService);
 
-  constructor(private readonly configService: ConfigService, private readonly logService: LogService) {
+  // Just to prevent streamers from showing bad words on stream
+  readonly hideBannedWords = new FormControl(true, { nonNullable: true });
+  readonly bannedWords = new FormControl('', { nonNullable: true });
+
+  constructor() {
     this.configService.bannedWords$
       .pipe(takeUntilDestroyed())
       .subscribe((bannedWords) => {

--- a/src/app/pages/settings/amazon-polly/amazon-polly.component.ts
+++ b/src/app/pages/settings/amazon-polly/amazon-polly.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ConfigService } from '../../../shared/services/config.service';
 import voices from '../../../shared/json/amazon-polly.json';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -31,17 +31,18 @@ import { SelectorComponent } from '../../../shared/components/selector/selector.
   ],
 })
 export class AmazonPollyComponent {
-  regions = voices.regions.map<{ value: string, displayName: string }>(r => ({ value: r, displayName: r }));
+  private readonly configService = inject(ConfigService);
+  readonly regions = voices.regions.map<{ value: string, displayName: string }>(r => ({ value: r, displayName: r }));
   readonly voices = voices.options;
 
-  amazonPollyGroup = new FormGroup({
+  readonly amazonPollyGroup = new FormGroup({
     region: new FormControl(this.regions[0].value, { nonNullable: true }),
     poolId: new FormControl('', { nonNullable: true }),
     language: new FormControl('', { nonNullable: true }),
     voice: new FormControl('', { nonNullable: true }),
   });
 
-  constructor(private readonly configService: ConfigService) {
+  constructor() {
     this.configService.amazonPolly$
       .pipe(takeUntilDestroyed())
       .subscribe((amazonPolly) => {

--- a/src/app/pages/settings/device/device.component.html
+++ b/src/app/pages/settings/device/device.component.html
@@ -8,7 +8,7 @@
   <app-selector
     placeholder="Select a device"
     [control]="selectedDevice"
-    [options]="deviceOptions"
+    [options]="deviceOptions()"
   />
 </app-label-block>
 

--- a/src/app/pages/settings/device/device.component.ts
+++ b/src/app/pages/settings/device/device.component.ts
@@ -1,4 +1,4 @@
-import { Component, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { debounceTime, filter, take } from 'rxjs';
 import { ConfigService } from 'src/app/shared/services/config.service';
@@ -34,19 +34,19 @@ import { InputComponent } from '../../../shared/components/input/input.component
   ],
 })
 export class DeviceComponent {
-  devices = signal<WithId<DeviceInfo, DeviceId>[]>([]);
-  deviceOptions: TTSOption[] = [];
-  selectedDevice = new FormControl(0, { nonNullable: true });
-  volume = new FormControl(100, { nonNullable: true });
-  audioDelay = new FormControl(0, { nonNullable: true, validators: [Validators.min(0)] });
+  private readonly configService = inject(ConfigService);
+  private readonly playbackService = inject(PlaybackService);
 
-  constructor(
-    private readonly configService: ConfigService,
-    private readonly playbackService: PlaybackService,
-  ) {
+  readonly deviceOptions = signal<TTSOption[]>([]);
+  readonly devices = signal<WithId<DeviceInfo, DeviceId>[]>([]);
+  readonly selectedDevice = new FormControl(0, { nonNullable: true });
+  readonly volume = new FormControl(100, { nonNullable: true });
+  readonly audioDelay = new FormControl(0, { nonNullable: true, validators: [Validators.min(0)] });
+
+  constructor() {
     this.playbackService.listOutputDevices().then((devices) => {
       this.devices.set(devices.outputDevices);
-      this.deviceOptions = devices.outputDevices.map(d => ({ displayName: d.name, value: d.id }));
+      this.deviceOptions.set(devices.outputDevices.map(d => ({ displayName: d.name, value: d.id })));
     });
 
     this.configService.selectedDevice$

--- a/src/app/pages/settings/eleven-labs/eleven-labs.component.ts
+++ b/src/app/pages/settings/eleven-labs/eleven-labs.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { InputComponent } from '../../../shared/components/input/input.component';
 import { LabelBlockComponent } from '../../../shared/components/input-block/label-block.component';
@@ -16,7 +16,9 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   styleUrl: './eleven-labs.component.scss',
 })
 export class ElevenLabsComponent {
-  elevenLabs = new FormGroup({
+  private readonly elevenLabsService = inject(ElevenLabsService);
+
+  readonly elevenLabs = new FormGroup({
     apiKey: new FormControl('', { nonNullable: true }),
     voiceId: new FormControl('', { nonNullable: true }),
     modelId: new FormControl('', { nonNullable: true }),
@@ -25,7 +27,7 @@ export class ElevenLabsComponent {
   voiceOptions: TTSOption[] = [];
   modelOptions: TTSOption[] = [];
 
-  constructor(private readonly elevenLabsService: ElevenLabsService) {
+  constructor() {
     this.elevenLabsService.state$
       .pipe(takeUntilDestroyed())
       .subscribe(state => {

--- a/src/app/pages/settings/settings.component.ts
+++ b/src/app/pages/settings/settings.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ConfigService } from 'src/app/shared/services/config.service';
 import { AudioService } from 'src/app/shared/services/audio.service';
@@ -40,9 +40,12 @@ interface TtsOption {
   ],
 })
 export class SettingsComponent {
-  ttsControl = new FormControl('', { nonNullable: true });
-  selectedTts = new FormControl<TtsType>('stream-elements', { nonNullable: true });
-  ttsOptions: Array<TtsOption> = [
+  private readonly audioService = inject(AudioService);
+  private readonly configService = inject(ConfigService);
+
+  readonly ttsControl = new FormControl('', { nonNullable: true });
+  readonly selectedTts = new FormControl<TtsType>('stream-elements', { nonNullable: true });
+  readonly ttsOptions: Array<TtsOption> = [
     {
       displayValue: 'StreamElements',
       value: 'stream-elements',
@@ -66,10 +69,7 @@ export class SettingsComponent {
     },
   ];
 
-  constructor(
-    private readonly audioService: AudioService,
-    private readonly configService: ConfigService,
-  ) {
+  constructor() {
     this.configService.configTts$
       .pipe(takeUntilDestroyed())
       .subscribe((tts) => {

--- a/src/app/pages/settings/streamelement-tts/stream-elements.component.ts
+++ b/src/app/pages/settings/streamelement-tts/stream-elements.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ConfigService } from 'src/app/shared/services/config.service';
 import voices from '../../../shared/json/stream-elements.json';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -13,13 +13,14 @@ import { FormControl, FormGroup } from '@angular/forms';
   imports: [TtsSelectorComponent],
 })
 export class StreamElementsComponent {
+  private readonly configService = inject(ConfigService);
   readonly voices = voices;
-  streamElementsGroup = new FormGroup({
+  readonly streamElementsGroup = new FormGroup({
     voice: new FormControl('', { nonNullable: true }),
     language: new FormControl('', { nonNullable: true }),
   });
 
-  constructor(private readonly configService: ConfigService) {
+  constructor() {
     this.configService.streamElements$
       .pipe(takeUntilDestroyed())
       .subscribe((streamElements) => {
@@ -31,7 +32,7 @@ export class StreamElementsComponent {
     this.streamElementsGroup.valueChanges
       .pipe(takeUntilDestroyed())
       .subscribe((streamElements) =>
-        this.configService.updateStreamElements(streamElements)
+        this.configService.updateStreamElements(streamElements),
       );
   }
 }

--- a/src/app/pages/settings/tiktok/tiktok.component.ts
+++ b/src/app/pages/settings/tiktok/tiktok.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ConfigService } from 'src/app/shared/services/config.service';
 import voices from '../../../shared/json/tiktok.json';
@@ -14,11 +14,12 @@ import { FormControl } from '@angular/forms';
   imports: [CommonModule, TtsSelectorComponent],
 })
 export class TiktokComponent {
+  private readonly configService = inject(ConfigService);
   readonly voices = voices;
-  voiceControl = new FormControl('', { nonNullable: true });
-  languageControl = new FormControl('', { nonNullable: true });
+  readonly voiceControl = new FormControl('', { nonNullable: true });
+  readonly languageControl = new FormControl('', { nonNullable: true });
 
-  constructor(private readonly configService: ConfigService) {
+  constructor() {
     this.configService.tikTok$
       .pipe(takeUntilDestroyed())
       .subscribe((tikTok) => {
@@ -34,7 +35,7 @@ export class TiktokComponent {
     this.languageControl.valueChanges
       .pipe(takeUntilDestroyed())
       .subscribe((language) =>
-        this.configService.updateTikTokLanguage(language)
+        this.configService.updateTikTokLanguage(language),
       );
 
     this.voiceControl.valueChanges

--- a/src/app/pages/settings/tts-monster/tts-monster.component.ts
+++ b/src/app/pages/settings/tts-monster/tts-monster.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ConfigService } from 'src/app/shared/services/config.service';
 import { InputComponent } from '../../../shared/components/input/input.component';
@@ -13,10 +13,11 @@ import { LabelBlockComponent } from '../../../shared/components/input-block/labe
   imports: [InputComponent, LabelBlockComponent],
 })
 export class TtsMonsterComponent {
-  overlay = new FormControl('', { nonNullable: true });
-  ai = new FormControl(false, { nonNullable: true });
+  private readonly configService = inject(ConfigService);
+  readonly overlay = new FormControl('', { nonNullable: true });
+  readonly ai = new FormControl(false, { nonNullable: true });
 
-  constructor(private readonly configService: ConfigService) {
+  constructor() {
     this.configService.ttsMonster$
       .pipe(takeUntilDestroyed())
       .subscribe((ttsMonster) => {

--- a/src/app/pages/tools/captions/captions.component.ts
+++ b/src/app/pages/tools/captions/captions.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LabelBlockComponent } from '../../../shared/components/input-block/label-block.component';
 import { InputComponent } from '../../../shared/components/input/input.component';
@@ -18,11 +18,14 @@ import { MatSnackBar } from '@angular/material/snack-bar';
   styleUrl: './captions.component.scss',
 })
 export class CaptionsComponent {
-  maxWidthControl = new FormControl(300, { nonNullable: true });
-  fontSizeControl = new FormControl(16, { nonNullable: true });
-  borderSizeControl = new FormControl(2, { nonNullable: true });
-  borderRadiusControl = new FormControl(6, { nonNullable: true });
-  paddingControl = new FormControl('10', { nonNullable: true });
+  private readonly twitchService = inject(TwitchService);
+  private readonly snackbar = inject(MatSnackBar);
+
+  readonly maxWidthControl = new FormControl(300, { nonNullable: true });
+  readonly fontSizeControl = new FormControl(16, { nonNullable: true });
+  readonly borderSizeControl = new FormControl(2, { nonNullable: true });
+  readonly borderRadiusControl = new FormControl(6, { nonNullable: true });
+  readonly paddingControl = new FormControl('10', { nonNullable: true });
 
   backgroundColor: RGBAString = 'rgba(100, 37, 175, 0.48)';
   fontColor: RGBAString = 'rgba(255, 255, 255, 1)';
@@ -37,7 +40,7 @@ export class CaptionsComponent {
 
   username = 'Alphyx';
 
-  constructor(private readonly twitchService: TwitchService, private readonly snackbar: MatSnackBar) {
+  constructor() {
     this.twitchService.channelInfo$
       .subscribe(info => this.username = info.username ?? 'Alphyx');
 

--- a/src/app/pages/twitch/auth/auth.component.ts
+++ b/src/app/pages/twitch/auth/auth.component.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, Component, signal } from '@angular/core';
+import { ApplicationRef, Component, inject, signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { combineLatest } from 'rxjs';
 import { TwitchService } from 'src/app/shared/services/twitch.service';
@@ -15,6 +15,9 @@ export type ConnectionType = 'Connected' | 'Disconnected' | 'Expired';
   imports: [NgClass, NgIf, LabelBlockComponent, AsyncPipe],
 })
 export class AuthComponent {
+  private readonly twitchService = inject(TwitchService);
+  private readonly ref = inject(ApplicationRef);
+
   // Rust server running so we can auth in the users browser
   private readonly redirect = 'http://localhost:12583/auth/twitch';
   private readonly clientId = 'fprxp4ve0scf8xg6y48nwcq1iogxuq';
@@ -26,10 +29,7 @@ export class AuthComponent {
   connectionMessage = signal('');
   isTokenValid = toSignal(this.twitchService.isTokenValid$);
 
-  constructor(
-    private readonly twitchService: TwitchService,
-    private readonly ref: ApplicationRef,
-  ) {
+  constructor() {
     combineLatest([
       this.twitchService.isTokenValid$,
       this.twitchService.token$,

--- a/src/app/pages/twitch/bits/bits.component.ts
+++ b/src/app/pages/twitch/bits/bits.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, Validators } from '@angular/forms';
 import { debounceTime, filter } from 'rxjs';
@@ -17,18 +17,19 @@ import { LabelBlockComponent } from '../../../shared/components/input-block/labe
   imports: [ToggleComponent, NgIf, InputComponent, MatFormFieldModule, LabelBlockComponent],
 })
 export class BitsComponent {
-  minBits = new FormControl(0, {
+  private readonly twitchService = inject(TwitchService);
+  readonly minBits = new FormControl(0, {
     nonNullable: true,
     validators: [Validators.min(0), Validators.pattern('^-?[0-9]+$')],
   });
-  bitsCharLimit = new FormControl(300, {
+  readonly bitsCharLimit = new FormControl(300, {
     nonNullable: true,
     validators: [Validators.min(0), Validators.pattern('^-?[0-9]+$')],
   });
-  enabled = new FormControl(true, { nonNullable: true });
-  exact = new FormControl(false, { nonNullable: true });
+  readonly enabled = new FormControl(true, { nonNullable: true });
+  readonly exact = new FormControl(false, { nonNullable: true });
 
-  constructor(private readonly twitchService: TwitchService) {
+  constructor() {
     this.twitchService.bitInfo$
       .pipe(takeUntilDestroyed())
       .subscribe((bitInfo) => {
@@ -44,7 +45,7 @@ export class BitsComponent {
       .pipe(
         takeUntilDestroyed(),
         debounceTime(1000),
-        filter(() => this.minBits.valid)
+        filter(() => this.minBits.valid),
       )
       .subscribe((minBits) => {
         this.twitchService.updateMinBits(Number(minBits));
@@ -54,7 +55,7 @@ export class BitsComponent {
       .pipe(
         takeUntilDestroyed(),
         debounceTime(1000),
-        filter(() => this.bitsCharLimit.valid)
+        filter(() => this.bitsCharLimit.valid),
       )
       .subscribe((bitsCharLimit) => {
         this.twitchService.updateBitsCharLimit(Number(bitsCharLimit));

--- a/src/app/pages/twitch/redeems/redeems.component.ts
+++ b/src/app/pages/twitch/redeems/redeems.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { debounceTime, map } from 'rxjs';
@@ -27,7 +27,10 @@ import { OpenAIService } from '../../../shared/services/openai.service';
   ],
 })
 export class RedeemsComponent {
-  redeemInfo = new FormGroup({
+  private readonly twitchService = inject(TwitchService);
+  private readonly openAIService = inject(OpenAIService);
+
+  readonly redeemInfo = new FormGroup({
     enabled: new FormControl(true, { nonNullable: true }),
     redeem: new FormControl('', { nonNullable: true }),
     gptRedeem: new FormControl('', { nonNullable: true }),
@@ -37,23 +40,21 @@ export class RedeemsComponent {
     }),
   });
 
-  gptEnabled = toSignal(this.openAIService.enabled$);
-
-  redeems$ = this.twitchService.redeems$;
-  redeemOptions$ = this.twitchService.redeems$
+  readonly gptEnabled = toSignal(this.openAIService.enabled$);
+  readonly redeems$ = this.twitchService.redeems$;
+  readonly redeemOptions$ = this.twitchService.redeems$
     .pipe(
       takeUntilDestroyed(),
-      map(redeems => redeems.map<TTSOption>(r => ({ displayName: r.title, value: r.id })))
+      map(redeems => redeems.map<TTSOption>(r => ({ displayName: r.title, value: r.id }))),
     );
 
-  constructor(private readonly twitchService: TwitchService, private readonly openAIService: OpenAIService) {
+  constructor() {
     this.twitchService.redeemInfo$
       .pipe(takeUntilDestroyed())
       .subscribe((redeemInfo) => {
         this.redeemInfo.setValue(redeemInfo, { emitEvent: false });
       });
-
-
+    
     this.redeemInfo.valueChanges
       .pipe(takeUntilDestroyed(), debounceTime(500))
       .subscribe(redeemInfo => {

--- a/src/app/pages/twitch/settings/settings.component.ts
+++ b/src/app/pages/twitch/settings/settings.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LabelBlockComponent } from '../../../shared/components/input-block/label-block.component';
 import { FormControl, Validators } from '@angular/forms';
@@ -15,9 +15,13 @@ import { filter, take } from 'rxjs';
   styleUrl: './settings.component.scss',
 })
 export class SettingsComponent {
-  randomChance = new FormControl(0, { nonNullable: true, validators: [Validators.min(0), Validators.max(100)] });
+  private readonly twitchService = inject(TwitchService);
+  readonly randomChance = new FormControl(0, {
+    nonNullable: true,
+    validators: [Validators.min(0), Validators.max(100)],
+  });
 
-  constructor(private readonly twitchService: TwitchService) {
+  constructor() {
     this.twitchService.settings$
       .pipe(takeUntilDestroyed(), take(1))
       .subscribe(settings => this.randomChance.setValue(settings.randomChance, { emitEvent: false }));

--- a/src/app/pages/twitch/subs/subs.component.ts
+++ b/src/app/pages/twitch/subs/subs.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { debounceTime, filter } from 'rxjs';
@@ -30,19 +30,21 @@ import {
   ],
 })
 export class SubsComponent {
-  enabled = new FormControl(true, { nonNullable: true });
-  charLimit = new FormControl(300, {
+  private readonly twitchService = inject(TwitchService);
+
+  readonly charLimit = new FormControl(300, {
     nonNullable: true,
     validators: [Validators.min(0), Validators.pattern('^-?[0-9]+$')],
   });
-  giftMessage = new FormControl('', { nonNullable: true });
-
+  readonly enabled = new FormControl(true, { nonNullable: true });
+  readonly giftMessage = new FormControl('', { nonNullable: true });
+  
   readonly variables: VariableTableOption[] = [
     { variable: 'amount', descriptor: 'The number of subs gifted' },
     { variable: 'username', descriptor: 'The username of the gifter' },
   ];
 
-  constructor(private readonly twitchService: TwitchService) {
+  constructor() {
     this.twitchService.subsInfo$
       .pipe(takeUntilDestroyed())
       .subscribe((subsInfo) => {

--- a/src/app/pages/vstream/auth/auth.component.ts
+++ b/src/app/pages/vstream/auth/auth.component.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, Component, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LabelBlockComponent } from '../../../shared/components/input-block/label-block.component';
 import { ConnectionType } from '../../twitch/auth/auth.component';
@@ -13,15 +13,13 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   styleUrl: './auth.component.scss',
 })
 export class AuthComponent {
-  connectionStatus = signal<ConnectionType>('Disconnected');
-  connectionMessage = signal('');
-  isTokenValid = signal(false);
+  private readonly vStreamService = inject(VStreamService);
+  readonly connectionStatus = signal<ConnectionType>('Disconnected');
+  readonly connectionMessage = signal('');
+  readonly isTokenValid = signal(false);
   loginUrl = '';
 
-  constructor(
-    private readonly vStreamService: VStreamService,
-    private readonly ref: ApplicationRef,
-  ) {
+  constructor() {
     this.vStreamService.token$
       .pipe(takeUntilDestroyed())
       .subscribe(token => {

--- a/src/app/pages/vstream/chat-commands/chat-commands.component.ts
+++ b/src/app/pages/vstream/chat-commands/chat-commands.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { VStreamService } from '../../../shared/services/vstream.service';
 import { EditCommandComponent } from './edit-command/edit-command.component';
@@ -14,10 +14,10 @@ import { LabelBlockComponent } from '../../../shared/components/input-block/labe
   styleUrl: './chat-commands.component.scss',
 })
 export class ChatCommandsComponent {
+  private readonly vstreamService = inject(VStreamService);
+
   commands$ = this.vstreamService.commands$;
 
-  constructor(private readonly vstreamService: VStreamService) {}
-  
   createCommand() {
     this.vstreamService.createChatCommand();
   }

--- a/src/app/pages/vstream/chat-commands/chat-commands.component.ts
+++ b/src/app/pages/vstream/chat-commands/chat-commands.component.ts
@@ -16,7 +16,7 @@ import { LabelBlockComponent } from '../../../shared/components/input-block/labe
 export class ChatCommandsComponent {
   private readonly vstreamService = inject(VStreamService);
 
-  commands$ = this.vstreamService.commands$;
+  readonly commands$ = this.vstreamService.commands$;
 
   createCommand() {
     this.vstreamService.createChatCommand();

--- a/src/app/pages/vstream/chat-commands/edit-command/edit-command.component.ts
+++ b/src/app/pages/vstream/chat-commands/edit-command/edit-command.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ChatCommand } from '../../../../shared/services/chat.interface';
 import { CdkAccordionModule } from '@angular/cdk/accordion';
@@ -21,9 +21,11 @@ import { MatTabsModule } from '@angular/material/tabs';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class EditCommandComponent implements OnInit {
+  private readonly vstreamService = inject(VStreamService);
+
   @Input({ required: true }) command!: ChatCommand;
 
-  commandSettings = new FormGroup({
+  readonly commandSettings = new FormGroup({
     command: new FormControl('', { nonNullable: true, validators: [Validators.minLength(1)] }),
     enabled: new FormControl(false, { nonNullable: true }),
     autoRedeem: new FormControl(false, { nonNullable: true }),
@@ -32,13 +34,13 @@ export class EditCommandComponent implements OnInit {
     cooldown: new FormControl(0, { nonNullable: true }),
   });
 
-  permissions = new FormGroup({
+  readonly permissions = new FormGroup({
     allUsers: new FormControl(false, { nonNullable: true }),
     mods: new FormControl(false, { nonNullable: true }),
     payingMembers: new FormControl(false, { nonNullable: true }),
   });
 
-  constructor(private readonly vstreamService: VStreamService) {
+  constructor() {
     this.commandSettings.valueChanges
       .pipe(filter(() => this.commandSettings.valid))
       .subscribe(settings => {

--- a/src/app/pages/vstream/followers/followers.component.ts
+++ b/src/app/pages/vstream/followers/followers.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LabelBlockComponent } from '../../../shared/components/input-block/label-block.component';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
@@ -19,16 +19,17 @@ import { VStreamEventVariables } from '../utils/variables';
   styleUrl: './followers.component.scss',
 })
 export class FollowersComponent {
+  private readonly vstreamService = inject(VStreamService);
   readonly variables: VariableTableOption[] = VStreamEventVariables.new_follower.variables;
 
-  settings = new FormGroup({
+  readonly settings = new FormGroup({
     enabled: new FormControl(false, { nonNullable: true }),
     enabledGpt: new FormControl(false, { nonNullable: true }),
     enabledChat: new FormControl(false, { nonNullable: true }),
     customMessage: new FormControl('', { nonNullable: true }),
   });
 
-  constructor(private readonly vstreamService: VStreamService) {
+  constructor() {
     this.vstreamService.followerSettings$
       .pipe(takeUntilDestroyed())
       .subscribe(settings => {

--- a/src/app/pages/vstream/meteor-shower/meteor-shower.component.ts
+++ b/src/app/pages/vstream/meteor-shower/meteor-shower.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { LabelBlockComponent } from '../../../shared/components/input-block/label-block.component';
@@ -20,16 +20,17 @@ import { VStreamEventVariables } from '../utils/variables';
   styleUrl: './meteor-shower.component.scss',
 })
 export class MeteorShowerComponent {
+  private readonly vstreamService = inject(VStreamService);
+  
   readonly variables: VariableTableOption[] = VStreamEventVariables.shower_received.variables;
-
-  settings = new FormGroup({
+  readonly settings = new FormGroup({
     enabled: new FormControl(false, { nonNullable: true }),
     enabledGpt: new FormControl(false, { nonNullable: true }),
     enabledChat: new FormControl(false, { nonNullable: true }),
     customMessage: new FormControl('', { nonNullable: true }),
   });
 
-  constructor(private readonly vstreamService: VStreamService) {
+  constructor() {
     this.vstreamService.meteorShowerSettings$
       .pipe(takeUntilDestroyed())
       .subscribe(settings => {

--- a/src/app/pages/vstream/overlays/edit-widget/edit-widget.component.ts
+++ b/src/app/pages/vstream/overlays/edit-widget/edit-widget.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, inject, Input, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatDialogActions, MatDialogContent, MatDialogTitle } from '@angular/material/dialog';
 import { LabelBlockComponent } from '../../../../shared/components/input-block/label-block.component';
@@ -27,9 +27,11 @@ import { ToggleComponent } from '../../../../shared/components/toggle/toggle.com
   styleUrl: './edit-widget.component.scss',
 })
 export class EditWidgetComponent implements OnInit {
+  private readonly vstreamService = inject(VStreamService);
+
   @Input({ required: true }) widget!: VStreamWidget;
 
-  eventOptions: { value: VStreamEventTypes, displayName: string }[] = [
+  readonly eventOptions: { value: VStreamEventTypes, displayName: string }[] = [
     { value: 'new_follower', displayName: 'Follower' },
     { value: 'uplifting_chat_sent', displayName: 'UpLift' },
     { value: 'subscriptions_gifted', displayName: 'Gift Sub' },
@@ -37,7 +39,7 @@ export class EditWidgetComponent implements OnInit {
     { value: 'shower_received', displayName: 'Meteor Shower' },
   ];
 
-  fontPositions = ['top', 'left', 'bottom', 'right', 'center'];
+  readonly fontPositions = ['top', 'left', 'bottom', 'right', 'center'];
 
   fontColor = '#fff';
 
@@ -45,7 +47,7 @@ export class EditWidgetComponent implements OnInit {
 
   enabled = new FormControl(true, { nonNullable: true });
 
-  settings = new FormGroup({
+  readonly settings = new FormGroup({
     trigger: new FormControl<VStreamEventTypes>('new_follower', {
       nonNullable: true,
       validators: [Validators.required],
@@ -65,7 +67,7 @@ export class EditWidgetComponent implements OnInit {
     fadeOutDuration: new FormControl(300, { nonNullable: true }),
   });
 
-  constructor(private readonly vstreamService: VStreamService) {
+  constructor() {
     this.settings.controls.trigger.valueChanges
       .subscribe(trigger => {
         this.variables = VStreamEventVariables[trigger];

--- a/src/app/pages/vstream/settings/settings.component.ts
+++ b/src/app/pages/vstream/settings/settings.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { InputComponent } from '../../../shared/components/input/input.component';
 import { LabelBlockComponent } from '../../../shared/components/input-block/label-block.component';
@@ -16,9 +16,13 @@ import { RouterLink } from '@angular/router';
   styleUrl: './settings.component.scss',
 })
 export class SettingsComponent {
-  randomChance = new FormControl(0, { nonNullable: true, validators: [Validators.min(0), Validators.max(100)] });
+  private readonly vstreamService = inject(VStreamService);
+  readonly randomChance = new FormControl(0, {
+    nonNullable: true,
+    validators: [Validators.min(0), Validators.max(100)],
+  });
 
-  constructor(private readonly vstreamService: VStreamService) {
+  constructor() {
     this.vstreamService.settings$
       .pipe(takeUntilDestroyed())
       .subscribe(settings => {

--- a/src/app/pages/vstream/subscription/subscription.component.ts
+++ b/src/app/pages/vstream/subscription/subscription.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { InputComponent } from '../../../shared/components/input/input.component';
 import { LabelBlockComponent } from '../../../shared/components/input-block/label-block.component';
@@ -20,24 +20,25 @@ import { VStreamEventVariables } from '../utils/variables';
   styleUrl: './subscription.component.scss',
 })
 export class SubscriptionComponent {
+  private readonly vstreamService = inject(VStreamService);
   readonly renewVariables: VariableTableOption[] = VStreamEventVariables.subscription_renewed.variables;
   readonly giftedVariables: VariableTableOption[] = VStreamEventVariables.subscriptions_gifted.variables;
 
-  renewSettings = new FormGroup({
+  readonly renewSettings = new FormGroup({
     enabled: new FormControl(false, { nonNullable: true }),
     enabledGpt: new FormControl(false, { nonNullable: true }),
     enabledChat: new FormControl(false, { nonNullable: true }),
     customMessage: new FormControl('', { nonNullable: true }),
   });
 
-  giftedSettings = new FormGroup({
+  readonly giftedSettings = new FormGroup({
     enabled: new FormControl(false, { nonNullable: true }),
     enabledGpt: new FormControl(false, { nonNullable: true }),
     enabledChat: new FormControl(false, { nonNullable: true }),
     customMessage: new FormControl('', { nonNullable: true }),
   });
 
-  constructor(private readonly vstreamService: VStreamService) {
+  constructor() {
     this.vstreamService.subscriptionSettings$
       .pipe(takeUntilDestroyed())
       .subscribe(settings => {

--- a/src/app/pages/vstream/uplifts/uplifts.component.ts
+++ b/src/app/pages/vstream/uplifts/uplifts.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LabelBlockComponent } from '../../../shared/components/input-block/label-block.component';
 import { ToggleComponent } from '../../../shared/components/toggle/toggle.component';
@@ -19,16 +19,17 @@ import { VStreamEventVariables } from '../utils/variables';
   styleUrl: './uplifts.component.scss',
 })
 export class UpliftsComponent {
+  private readonly vstreamService = inject(VStreamService);
   readonly variables: VariableTableOption[] = VStreamEventVariables.uplifting_chat_sent.variables;
 
-  settings = new FormGroup({
+  readonly settings = new FormGroup({
     enabled: new FormControl(false, { nonNullable: true }),
     enabledGpt: new FormControl(false, { nonNullable: true }),
     enabledChat: new FormControl(false, { nonNullable: true }),
     customMessage: new FormControl('', { nonNullable: true }),
   });
 
-  constructor(private readonly vstreamService: VStreamService) {
+  constructor() {
     this.vstreamService.upliftSettings$
       .pipe(takeUntilDestroyed())
       .subscribe(settings => {

--- a/src/app/pages/vtubestudio/vtubestudio.component.ts
+++ b/src/app/pages/vtubestudio/vtubestudio.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { LabelBlockComponent } from '../../shared/components/input-block/label-block.component';
 import { InputComponent } from '../../shared/components/input/input.component';
 import { FormControl, FormGroup } from '@angular/forms';
@@ -19,13 +19,14 @@ import { debounceTime, take } from 'rxjs';
   styleUrl: './vtubestudio.component.scss',
 })
 export class VtubestudioComponent {
-  settings = new FormGroup({
+  private readonly vtubeStudioService = inject(VTubeStudioService);
+  readonly settings = new FormGroup({
     port: new FormControl(8001, { nonNullable: true }),
     isMirrorMouthFormEnabled: new FormControl(false, { nonNullable: true }),
     isMirrorMouthOpenEnabled: new FormControl(false, { nonNullable: true }),
   });
 
-  constructor(private readonly vtubeStudioService: VTubeStudioService) {
+  constructor() {
     this.vtubeStudioService.state$
       .pipe(takeUntilDestroyed(), take(1))
       .subscribe(state => {

--- a/src/app/shared/api/eleven-labs/eleven-labs.api.ts
+++ b/src/app/shared/api/eleven-labs/eleven-labs.api.ts
@@ -1,4 +1,4 @@
-﻿import { Injectable } from '@angular/core';
+﻿import { inject, Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { ElevenLabsModel, ElevenLabsVoice } from './eleven-labs.interface';
 import { Store } from '@ngrx/store';
@@ -8,10 +8,12 @@ import { ElevenLabsFeature } from '../../state/eleven-labs/eleven-labs.feature';
   providedIn: 'root',
 })
 export class ElevenLabsApi {
+  private readonly http = inject(HttpClient);
+  private readonly store = inject(Store);
   private readonly apiUrl = 'https://api.elevenlabs.io/v1';
   private apiKey = '';
 
-  constructor(private readonly http: HttpClient, private readonly store: Store) {
+  constructor() {
     this.store.select(ElevenLabsFeature.selectApiKey)
       .subscribe(apiKey => this.apiKey = apiKey);
   }

--- a/src/app/shared/api/twitch/twitch.api.ts
+++ b/src/app/shared/api/twitch/twitch.api.ts
@@ -1,6 +1,6 @@
-﻿import { Injectable, OnDestroy } from '@angular/core';
+﻿import { inject, Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { Observable, Subject } from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { TwitchRedeem } from './twitch.interface';
 import { ValidUser } from '../../state/twitch/twitch.feature';
@@ -8,18 +8,12 @@ import { ValidUser } from '../../state/twitch/twitch.feature';
 @Injectable({
   providedIn: 'root',
 })
-export class TwitchApi implements OnDestroy {
-  private readonly destroyed$ = new Subject<void>();
+export class TwitchApi {
+  private readonly http = inject(HttpClient);
+
   private readonly apiUrl = 'https://api.twitch.tv/helix';
   private readonly url = 'https://id.twitch.tv';
   private readonly clientId = 'fprxp4ve0scf8xg6y48nwcq1iogxuq';
-
-  constructor(private readonly http: HttpClient) {}
-
-  ngOnDestroy(): void {
-    this.destroyed$.next();
-    this.destroyed$.complete();
-  }
 
   /**
    * Get channels possible redeems so they can configure TTS for each redeem.

--- a/src/app/shared/api/vstream/vstream.api.ts
+++ b/src/app/shared/api/vstream/vstream.api.ts
@@ -1,4 +1,4 @@
-﻿import { Injectable } from '@angular/core';
+﻿import { inject, Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import CryptoJS from 'crypto-js';
 import { VStreamTokenResponse } from '../../state/vstream/vstream.feature';
@@ -9,13 +9,13 @@ import { VStreamAPIChannelVideoLiveStream } from './vstream.interface';
   providedIn: 'root',
 })
 export class VStreamApi {
+  private readonly http = inject(HttpClient);
+
   private readonly clientId = '018c3d0a-6e23-7000-b15f-3bf29bb3111d';
   private readonly redirectUri = 'http://localhost:12583/auth/vstream';
   private readonly url = 'https://api.vstream.com';
   private readonly scopes = ['chat:write', 'openid', 'offline_access', 'profile'];
   #tokenVerifier = '';
-
-  constructor(private readonly http: HttpClient) {}
 
   generateCodeVerifier(): string {
     // Generate 96 random bytes

--- a/src/app/shared/components/audio-item/audio-item.component.ts
+++ b/src/app/shared/components/audio-item/audio-item.component.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { ApplicationRef, ChangeDetectionStrategy, Component, EventEmitter, inject, Input, Output } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { AudioService } from 'src/app/shared/services/audio.service';
 import { DatePipe, NgClass } from '@angular/common';
@@ -16,18 +16,16 @@ import { ButtonComponent } from '../button/button.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AudioItemComponent {
+  private readonly audioService = inject(AudioService);
+  private readonly playbackService = inject(PlaybackService);
+  private readonly ref = inject(ApplicationRef);
+  private readonly logService = inject(LogService);
+  private readonly snackbar = inject(MatSnackBar);
+
   @Input({ required: true }) audio!: AudioItem;
   @Output() itemSkipped = new EventEmitter<number>();
 
   readonly AudioState = AudioStatus;
-
-  constructor(
-    private readonly audioService: AudioService,
-    private readonly playbackService: PlaybackService,
-    private readonly ref: ApplicationRef,
-    private readonly logService: LogService,
-    private readonly snackbar: MatSnackBar,
-  ) {}
 
   get svg() {
     return `assets/${this.audio.source.toLowerCase()}.svg`;

--- a/src/app/shared/components/audio-list/audio-list.component.ts
+++ b/src/app/shared/components/audio-list/audio-list.component.ts
@@ -3,7 +3,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AsyncPipe, NgClass, NgFor, NgIf } from '@angular/common';
 import { AudioItemComponent } from '../audio-item/audio-item.component';
 import { map } from 'rxjs';
-import { AudioItem, AudioStatus } from '../../state/audio/audio.feature';
+import { AudioStatus } from '../../state/audio/audio.feature';
 import { AudioService } from '../../services/audio.service';
 import { LabelBlockComponent } from '../input-block/label-block.component';
 
@@ -17,23 +17,18 @@ import { LabelBlockComponent } from '../input-block/label-block.component';
 export class AudioListComponent {
   @Input() filters?: AudioStatus[];
 
-  protected readonly AudioState = AudioStatus;
+  private readonly audioService = inject(AudioService);
   private readonly destroyRef = inject(DestroyRef);
+  protected readonly AudioState = AudioStatus;
 
-  audioItems$ = this.audioService.audioItems$
+  readonly audioItems$ = this.audioService.audioItems$
     .pipe(
       takeUntilDestroyed(this.destroyRef),
       map(items => items.filter(i => this.filters?.length ? this.filters.includes(i.state) : true)),
     );
-  currentlyPlaying$ = this.audioService.audioItems$
+  readonly currentlyPlaying$ = this.audioService.audioItems$
     .pipe(
       takeUntilDestroyed(this.destroyRef),
-      map(items => items.find(i => i.state === AudioStatus.playing))
+      map(items => items.find(i => i.state === AudioStatus.playing)),
     );
-
-  constructor(private readonly audioService: AudioService) {}
-
-  trackBy(index: number, item: AudioItem) {
-    return item.id;
-  }
 }

--- a/src/app/shared/components/nav/nav.component.ts
+++ b/src/app/shared/components/nav/nav.component.ts
@@ -1,5 +1,5 @@
 import { BreakpointObserver } from '@angular/cdk/layout';
-import { Component, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { SidenavComponent } from '../sidenav/sidenav.component';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatIconModule } from '@angular/material/icon';
@@ -27,13 +27,10 @@ import { PlaybackService } from '../../services/playback.service';
   ],
 })
 export class NavComponent implements OnInit {
+  private readonly breakpoint = inject(BreakpointObserver);
+  private readonly playbackService = inject(PlaybackService);
+  readonly isPaused$ = this.playbackService.isPaused$;
   isMobile = false;
-  isPaused$ = this.playbackService.isPaused$;
-
-  constructor(
-    private readonly breakpoint: BreakpointObserver,
-    private readonly playbackService: PlaybackService,
-  ) {}
 
   ngOnInit(): void {
     this.breakpoint.observe(['(max-width: 900px)']).subscribe((state) => {

--- a/src/app/shared/components/sidenav/sidenav.component.ts
+++ b/src/app/shared/components/sidenav/sidenav.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, inject, Input } from '@angular/core';
 import { MatSidenav } from '@angular/material/sidenav';
 import { getVersion } from '@tauri-apps/api/app';
 import { MatIconModule } from '@angular/material/icon';
@@ -18,6 +18,10 @@ import { VStreamService } from '../../services/vstream.service';
   imports: [RouterLink, RouterLinkActive, MatIconModule, NgOptimizedImage, NgClass, AsyncPipe],
 })
 export class SidenavComponent {
+  private readonly twitchService = inject(TwitchService);
+  private readonly vtsService = inject(VTubeStudioService);
+  private readonly vstreamService = inject(VStreamService);
+
   @Input({ required: true }) nav!: MatSidenav;
   @Input() isMobile = false;
   appVersion = '';
@@ -37,11 +41,7 @@ export class SidenavComponent {
       this.newVersion = true;
     });
 
-  constructor(
-    private readonly twitchService: TwitchService,
-    private readonly vtsService: VTubeStudioService,
-    private readonly vstreamService: VStreamService,
-  ) {
+  constructor() {
     getVersion().then((v) => (this.appVersion = v));
   }
 

--- a/src/app/shared/services/azure-stt.service.ts
+++ b/src/app/shared/services/azure-stt.service.ts
@@ -1,4 +1,4 @@
-﻿import { Injectable } from '@angular/core';
+﻿import { inject, Injectable } from '@angular/core';
 import {
   AudioConfig,
   CancellationDetails,
@@ -22,6 +22,12 @@ import { TwitchService } from './twitch.service';
   providedIn: 'root',
 })
 export class AzureSttService {
+  private readonly store = inject(Store);
+  private readonly openaiService = inject(OpenAIService);
+  private readonly logService = inject(LogService);
+  private readonly twitchService = inject(TwitchService);
+  private readonly snackbar = inject(MatSnackBar);
+
   public readonly subscriptionKey$ = this.store.select(AzureFeature.selectSubscriptionKey);
   public readonly region$ = this.store.select(AzureFeature.selectRegion);
   public readonly hotkey$ = this.store.select(AzureFeature.selectHotkey);
@@ -35,13 +41,7 @@ export class AzureSttService {
   isEnabled = false;
   isCurrentlyListening = false;
 
-  constructor(
-    private readonly store: Store,
-    private readonly openaiService: OpenAIService,
-    private readonly logService: LogService,
-    private readonly twitchService: TwitchService,
-    private readonly snackbar: MatSnackBar,
-  ) {
+  constructor() {
     combineLatest([
       this.subscriptionKey$,
       this.region$,

--- a/src/app/shared/services/config.service.ts
+++ b/src/app/shared/services/config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import {
   AmazonPollyData,
@@ -15,6 +15,8 @@ import { ChatPermissions } from './chat.interface';
   providedIn: 'root',
 })
 export class ConfigService {
+  private readonly store = inject(Store);
+  private readonly playbackService = inject(PlaybackService);
   public readonly state$ = this.store.select(ConfigFeature.selectGlobalConfigState);
   public readonly streamElements$ = this.store.select(ConfigFeature.selectStreamElements);
   public readonly ttsMonster$ = this.store.select(ConfigFeature.selectTtsMonster);
@@ -28,11 +30,7 @@ export class ConfigService {
   public readonly generalChat$ = this.store.select(ConfigFeature.selectGeneralChat);
   public readonly authTokens$ = this.store.select(ConfigFeature.selectAuthTokens);
   public readonly audioDelay$ = this.store.select(ConfigFeature.selectAudioDelay);
-
-  constructor(
-    private readonly store: Store,
-    private readonly playbackService: PlaybackService,
-  ) {}
+  public readonly audioSettings$ = this.store.select(ConfigFeature.selectAudioSettings);
 
   updateVTSToken(vtsAuthToken: string) {
     this.store.dispatch(GlobalConfigActions.updateTokens({ tokens: { vtsAuthToken } }));

--- a/src/app/shared/services/eleven-labs.service.ts
+++ b/src/app/shared/services/eleven-labs.service.ts
@@ -1,4 +1,4 @@
-﻿import { Injectable } from '@angular/core';
+﻿import { inject, Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { ElevenLabsFeature, ElevenLabsState } from '../state/eleven-labs/eleven-labs.feature';
 import { ElevenLabsActions } from '../state/eleven-labs/eleven-labs.actions';
@@ -10,11 +10,13 @@ import { switchMap } from 'rxjs';
   providedIn: 'root',
 })
 export class ElevenLabsService {
+  private readonly store = inject(Store);
+  private readonly elevenLabsApi = inject(ElevenLabsApi);
   public readonly apiKey$ = this.store.select(ElevenLabsFeature.selectApiKey);
   public readonly state$ = this.store.select(ElevenLabsFeature.selectElevenLabsState);
   public readonly apiUrl = 'https://api.elevenlabs.io/v1';
 
-  constructor(private readonly store: Store, private readonly elevenLabsApi: ElevenLabsApi) {
+  constructor() {
     this.apiKey$
       .pipe(
         takeUntilDestroyed(),

--- a/src/app/shared/services/openai.service.ts
+++ b/src/app/shared/services/openai.service.ts
@@ -1,4 +1,4 @@
-﻿import { Injectable } from '@angular/core';
+﻿import { inject, Injectable } from '@angular/core';
 import { AudioService } from './audio.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Configuration, OpenAIApi } from 'openai';
@@ -13,6 +13,10 @@ import { ChatPermissions } from './chat.interface';
   providedIn: 'root',
 })
 export class OpenAIService {
+  private readonly store = inject(Store);
+  private readonly audioService = inject(AudioService);
+  private readonly logService = inject(LogService);
+
   public readonly state$ = this.store.select(OpenAIFeature.selectOpenAIFeatureState);
   public readonly chatSettings$ = this.store.select(OpenAIFeature.selectChatSettings);
   public readonly settings$ = this.store.select(OpenAIFeature.selectSettings);
@@ -30,11 +34,7 @@ export class OpenAIService {
   chatGptConfig?: Configuration;
   openAIApi?: OpenAIApi;
 
-  constructor(
-    private readonly store: Store,
-    private readonly audioService: AudioService,
-    private readonly logService: LogService,
-  ) {
+  constructor() {
     this.chatSettings$
       .pipe(takeUntilDestroyed())
       .subscribe(chatSettings => this.chatSettings = chatSettings);

--- a/src/app/shared/services/playback.service.ts
+++ b/src/app/shared/services/playback.service.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, Injectable } from '@angular/core';
+import { ApplicationRef, inject, Injectable } from '@angular/core';
 import { invoke } from '@tauri-apps/api';
 import { listen } from '@tauri-apps/api/event';
 import { BehaviorSubject, from, Subject, tap } from 'rxjs';
@@ -20,6 +20,9 @@ import { AudioStatus } from '../state/audio/audio.feature';
   providedIn: 'root',
 })
 export class PlaybackService {
+  private readonly store = inject(Store);
+  private readonly ref = inject(ApplicationRef);
+  
   /**
    * Emits when an audio source starts playing.
    */
@@ -45,7 +48,7 @@ export class PlaybackService {
   currentlyPlaying: AudioId | null = null;
 
   // The Application ref helps make the history / queue view update once an item is finished/started/skipped etc.
-  constructor(private readonly store: Store, private readonly ref: ApplicationRef) {
+  constructor() {
     from(
       listen('playback::audio::start', (event) => {
         const id = event.payload as AudioId;

--- a/src/app/shared/services/twitch-pubsub.ts
+++ b/src/app/shared/services/twitch-pubsub.ts
@@ -1,5 +1,5 @@
 ﻿import { StaticAuthProvider } from '@twurple/auth';
-import { Injectable, OnDestroy } from '@angular/core';
+import { inject, Injectable, OnDestroy } from '@angular/core';
 import { TwitchService } from './twitch.service';
 import { combineLatest } from 'rxjs';
 import { ApiClient } from '@twurple/api';
@@ -19,15 +19,22 @@ import { ChatService } from './chat.service';
   providedIn: 'root',
 })
 export class TwitchPubSub implements OnDestroy {
+  private readonly twitchService = inject(TwitchService);
+  private readonly audioService = inject(AudioService);
+  private readonly logService = inject(LogService);
+  private readonly openaiService = inject(OpenAIService);
+  private readonly chatService = inject(ChatService);
+  private readonly snackbar = inject(MatSnackBar);
+
   // TTS Helper client ID. This isn't a sensitive code.
   private readonly clientId = 'fprxp4ve0scf8xg6y48nwcq1iogxuq';
 
   listener: EventSubWsListener | null = null;
   chat: ChatClient | null = null;
 
-  bitInfo = toSignal(this.twitchService.bitInfo$);
-  redeemInfo = toSignal(this.twitchService.redeemInfo$);
-  subsInfo = toSignal(this.twitchService.subsInfo$);
+  readonly bitInfo = toSignal(this.twitchService.bitInfo$);
+  readonly redeemInfo = toSignal(this.twitchService.redeemInfo$);
+  readonly subsInfo = toSignal(this.twitchService.subsInfo$);
 
   // Normal TTS chat command
   twitchSettings!: TwitchSettingsState;
@@ -45,14 +52,7 @@ export class TwitchPubSub implements OnDestroy {
   giftSubListener?: any;
   subMessageListener?: any;
 
-  constructor(
-    private readonly twitchService: TwitchService,
-    private readonly audioService: AudioService,
-    private readonly logService: LogService,
-    private readonly openaiService: OpenAIService,
-    private readonly chatService: ChatService,
-    private readonly snackbar: MatSnackBar,
-  ) {
+  constructor() {
     this.openaiService.settings$
       .pipe(takeUntilDestroyed())
       .subscribe(settings => this.gptSettings = settings);

--- a/src/app/shared/services/twitch.service.ts
+++ b/src/app/shared/services/twitch.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { inject, Injectable, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { catchError, of, skip, Subject, switchMap, takeUntil } from 'rxjs';
 import { listen } from '@tauri-apps/api/event';
@@ -12,6 +12,10 @@ import { TwitchApi } from '../api/twitch/twitch.api';
   providedIn: 'root',
 })
 export class TwitchService implements OnDestroy {
+  private readonly store = inject(Store);
+  private readonly twitchApi = inject(TwitchApi);
+  private readonly snackbar = inject(MatSnackBar);
+  private readonly logService = inject(LogService);
   private readonly destroyed$ = new Subject<void>();
 
   public readonly state$ = this.store.select(TwitchFeature.selectTwitchStateState);
@@ -25,12 +29,7 @@ export class TwitchService implements OnDestroy {
   public readonly redeemInfo$ = this.store.select(TwitchFeature.selectRedeemInfo);
   public readonly bitInfo$ = this.store.select(TwitchFeature.selectBitInfo);
 
-  constructor(
-    private readonly store: Store,
-    private readonly twitchApi: TwitchApi,
-    private readonly snackbar: MatSnackBar,
-    private readonly logService: LogService,
-  ) {
+  constructor() {
     this.token$.pipe(
       // Ignore default state.
       skip(1),

--- a/src/app/shared/services/vtubestudio.service.ts
+++ b/src/app/shared/services/vtubestudio.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { LogService } from './logs.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { v4 as uuid } from 'uuid';
@@ -20,6 +20,12 @@ import { BehaviorSubject, interval } from 'rxjs';
   providedIn: 'root',
 })
 export class VTubeStudioService {
+  private readonly store = inject(Store);
+  private readonly logService = inject(LogService);
+  private readonly playbackService = inject(PlaybackService);
+  private readonly configService = inject(ConfigService);
+  private readonly snackbar = inject(MatSnackBar);
+
   private readonly vtsBasics = {
     apiName: 'VTubeStudioPublicAPI',
     apiVersion: '1.0',
@@ -64,13 +70,7 @@ export class VTubeStudioService {
    */
   randomMouthInterval?: NodeJS.Timer = undefined;
 
-  constructor(
-    private readonly store: Store,
-    private readonly logService: LogService,
-    private readonly playbackService: PlaybackService,
-    private readonly configService: ConfigService,
-    private readonly snackbar: MatSnackBar,
-  ) {
+  constructor() {
     this.port$.pipe(takeUntilDestroyed())
       .subscribe(port => {
         this.port = port;

--- a/src/app/shared/state/config/config.feature.ts
+++ b/src/app/shared/state/config/config.feature.ts
@@ -211,10 +211,26 @@ export const ConfigFeature = createFeature({
   ),
   extraSelectors: ({
     selectBannedWords,
+    selectTts,
+    selectStreamElements,
+    selectTtsMonster,
+    selectAmazonPolly,
+    selectTikTok,
   }) => ({
     selectBannedWordsLength: createSelector(
       selectBannedWords,
       (bannedWords) => bannedWords.length,
+    ),
+    selectAudioSettings: createSelector(
+      selectTts,
+      selectBannedWords,
+      selectStreamElements,
+      selectTtsMonster,
+      selectAmazonPolly,
+      selectTikTok,
+      (tts, bannedWords, streamElements, ttsMonster, amazonPolly, tikTok) => ({
+        bannedWords, tts, streamElements, ttsMonster, amazonPolly, tikTok,
+      }),
     ),
   }),
 });

--- a/src/app/shared/state/usage/usage.feature.ts
+++ b/src/app/shared/state/usage/usage.feature.ts
@@ -1,0 +1,29 @@
+﻿export interface UsageState {
+  azure: {
+    // Count every time the user tries to use STT
+    speech_to_text_attempts: number;
+    // Count every time Azure recognizes STT
+    speech_to_text_success: number;
+    // Count every time STT is not recognized or fails.
+    speech_to_text_failures: number;
+  }
+  elevenLabs: {
+    history_count: number;
+  },
+  openAI: {
+    // How many tokens have been used by users lore + our generator specifics.
+    total_prompt_tokens: number;
+    // How many tokens OpenAI has used when returning generated content
+    total_completion_tokens: number;
+  },
+  twitch: {
+    // Keep track of some basic usage information from twitch users
+    user_redeems: Record<string, {
+      username: string;
+      // How many times the user used twitch redeems
+      total_redeems: number;
+      // How many string characters they've sent.
+      total_characters: number;
+    }>
+  },
+}


### PR DESCRIPTION
As the title says, moving all the constructor dependency injection to use the functional `inject()` instead.

Also adding a lot more const correctness by adding `readonly` were possible.