### PR TITLE
fix: vtubestudio so it's no longer prompting the user to auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tts-helper",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "author": {
     "email": "dylanwarren19@gmail.com",
     "name": "Dylan Warren",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "TTS Helper",
-    "version": "1.3.11"
+    "version": "1.3.12"
   },
   "tauri": {
     "allowlist": {

--- a/src/app/pages/vtubestudio/vtubestudio.component.html
+++ b/src/app/pages/vtubestudio/vtubestudio.component.html
@@ -10,6 +10,22 @@
 
 <div class="section">
   <app-label-block>
+    <div header>
+      @if (isAuthed$ | async) {
+        De-authorize
+      } @else {
+        Authorize
+      }
+    </div>
+    <div sub-text>Control TTS Helper's VTS auth level.</div>
+    @if (isAuthed$ | async) {
+      <app-button class="right" (click)="deauth()" [style]="'active'">De-authorize</app-button>
+    } @else {
+      <app-button class="right" (click)="auth()" [style]="'active'">Authorize</app-button>
+    }
+  </app-label-block>
+  
+  <app-label-block>
     <div header>API Port</div>
     <div sub-text>The port that's set in your VTS Plugin API settings.</div>
     <app-input [control]="settings.controls.port" type="number" placeholder="VTS port"/>

--- a/src/app/pages/vtubestudio/vtubestudio.component.ts
+++ b/src/app/pages/vtubestudio/vtubestudio.component.ts
@@ -5,7 +5,10 @@ import { FormControl, FormGroup } from '@angular/forms';
 import { ToggleComponent } from '../../shared/components/toggle/toggle.component';
 import { VTubeStudioService } from '../../shared/services/vtubestudio.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { debounceTime, take } from 'rxjs';
+import { debounceTime, map, take } from 'rxjs';
+import { ButtonComponent } from '../../shared/components/button/button.component';
+import { ConfigService } from '../../shared/services/config.service';
+import { AsyncPipe } from '@angular/common';
 
 @Component({
   selector: 'app-vtubestudio',
@@ -14,12 +17,17 @@ import { debounceTime, take } from 'rxjs';
     LabelBlockComponent,
     InputComponent,
     ToggleComponent,
+    ButtonComponent,
+    AsyncPipe,
   ],
   templateUrl: './vtubestudio.component.html',
   styleUrl: './vtubestudio.component.scss',
 })
 export class VtubestudioComponent {
   private readonly vtubeStudioService = inject(VTubeStudioService);
+  private readonly configService = inject(ConfigService);
+
+  readonly isAuthed$ = this.configService.authTokens$.pipe(map(tokens => !!tokens.vtsAuthToken));
   readonly settings = new FormGroup({
     port: new FormControl(8001, { nonNullable: true }),
     isMirrorMouthFormEnabled: new FormControl(false, { nonNullable: true }),
@@ -35,6 +43,14 @@ export class VtubestudioComponent {
 
     this.settings.valueChanges.pipe(takeUntilDestroyed(), debounceTime(200))
       .subscribe(settings => this.vtubeStudioService.updateState(settings));
+  }
+
+  auth() {
+    this.vtubeStudioService.auth();
+  }
+
+  deauth() {
+    this.vtubeStudioService.deauth();
   }
 }
 


### PR DESCRIPTION
This PR changes how VTubeStudio prompts users to auth.

Since many people using TTS Helper aren't using it for VTS, it's probably smart to put the auth behind a button on the VTS page.