### PR TITLE
fix: major memory leaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tts-helper",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "author": {
     "email": "dylanwarren19@gmail.com",
     "name": "Dylan Warren",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "TTS Helper",
-    "version": "1.4.2"
+    "version": "1.4.3"
   },
   "tauri": {
     "allowlist": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -32,6 +32,10 @@ import { VStreamState } from './shared/state/vstream/vstream.feature';
 import { VStreamActions } from './shared/state/vstream/vstream.actions';
 import { VStreamPubSubService } from './shared/services/vstream-pubsub.service';
 import { CounterCommand } from './shared/services/command.interface';
+import { AudioService } from './shared/services/audio.service';
+import { LogService } from './shared/services/logs.service';
+import { ChatService } from './shared/services/chat.service';
+import { CommandService } from './shared/services/command.service';
 
 @Component({
   selector: 'app-root',
@@ -39,6 +43,25 @@ import { CounterCommand } from './shared/services/command.interface';
   styleUrls: ['./app.component.scss'],
   standalone: true,
   imports: [NavComponent, RouterOutlet],
+  providers: [
+    AzureSttService,
+    AudioService,
+    ChatService,
+    CommandService,
+    ElevenLabsService,
+    ConfigService,
+    LogService,
+    OpenAIService,
+    ObsWebSocketService,
+    StreamDeckWebSocketService,
+    PlaybackService,
+    StorageService,
+    TwitchPubSub,
+    TwitchService,
+    VStreamService,
+    VStreamPubSubService,
+    VTubeStudioService,
+  ],
 })
 export class AppComponent {
   private readonly store = inject(Store);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -32,10 +32,6 @@ import { VStreamState } from './shared/state/vstream/vstream.feature';
 import { VStreamActions } from './shared/state/vstream/vstream.actions';
 import { VStreamPubSubService } from './shared/services/vstream-pubsub.service';
 import { CounterCommand } from './shared/services/command.interface';
-import { AudioService } from './shared/services/audio.service';
-import { LogService } from './shared/services/logs.service';
-import { ChatService } from './shared/services/chat.service';
-import { CommandService } from './shared/services/command.service';
 
 @Component({
   selector: 'app-root',
@@ -43,25 +39,6 @@ import { CommandService } from './shared/services/command.service';
   styleUrls: ['./app.component.scss'],
   standalone: true,
   imports: [NavComponent, RouterOutlet],
-  providers: [
-    AzureSttService,
-    AudioService,
-    ChatService,
-    CommandService,
-    ElevenLabsService,
-    ConfigService,
-    LogService,
-    OpenAIService,
-    ObsWebSocketService,
-    StreamDeckWebSocketService,
-    PlaybackService,
-    StorageService,
-    TwitchPubSub,
-    TwitchService,
-    VStreamService,
-    VStreamPubSubService,
-    VTubeStudioService,
-  ],
 })
 export class AppComponent {
   private readonly store = inject(Store);

--- a/src/app/pages/tools/captions/captions.component.ts
+++ b/src/app/pages/tools/captions/captions.component.ts
@@ -9,6 +9,7 @@ import { TwitchService } from '../../../shared/services/twitch.service';
 import { BorderString, captionsGenerator, PixelString, RGBAString } from './assets/captions';
 import { ButtonComponent } from '../../../shared/components/button/button.component';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-captions',
@@ -42,21 +43,27 @@ export class CaptionsComponent {
 
   constructor() {
     this.twitchService.channelInfo$
+      .pipe(takeUntilDestroyed())
       .subscribe(info => this.username = info.username ?? 'Alphyx');
 
     this.fontSizeControl.valueChanges
+      .pipe(takeUntilDestroyed())
       .subscribe(size => this.fontSize = `${size}px`);
 
     this.borderSizeControl.valueChanges
+      .pipe(takeUntilDestroyed())
       .subscribe(size => this.borderSize = `${size}px`);
 
     this.borderRadiusControl.valueChanges
+      .pipe(takeUntilDestroyed())
       .subscribe(size => this.borderRadius = `${size}px`);
 
     this.paddingControl.valueChanges
+      .pipe(takeUntilDestroyed())
       .subscribe(padding => this.parsePadding(padding));
 
     this.maxWidthControl.valueChanges
+      .pipe(takeUntilDestroyed())
       .subscribe(width => this.maxWidth = `${width}px`);
   }
 

--- a/src/app/pages/twitch/auth/auth.component.ts
+++ b/src/app/pages/twitch/auth/auth.component.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, Component, inject, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { combineLatest } from 'rxjs';
 import { TwitchService } from 'src/app/shared/services/twitch.service';
@@ -16,7 +16,6 @@ export type ConnectionType = 'Connected' | 'Disconnected' | 'Expired';
 })
 export class AuthComponent {
   private readonly twitchService = inject(TwitchService);
-  private readonly ref = inject(ApplicationRef);
 
   // Rust server running so we can auth in the users browser
   private readonly redirect = 'http://localhost:12583/auth/twitch';
@@ -53,12 +52,10 @@ export class AuthComponent {
           );
         }
 
-        this.ref.tick();
       });
   }
 
   signOut() {
     this.twitchService.signOut();
-    this.ref.tick();
   }
 }

--- a/src/app/pages/twitch/redeems/redeems.component.html
+++ b/src/app/pages/twitch/redeems/redeems.component.html
@@ -21,7 +21,7 @@
       <app-selector placeholder="Select a redeem option" [control]="redeemInfo.controls.redeem" [options]="(redeemOptions$ | async) ?? []" />
     </app-label-block>
 
-    @if (gptEnabled()) {
+    @if (gptEnabled$ | async) {
       <app-label-block>
         <div header>ChatGPT Redeem</div>
         <div sub-text>This redeem will trigger a ChatGPT response.</div>

--- a/src/app/pages/twitch/redeems/redeems.component.ts
+++ b/src/app/pages/twitch/redeems/redeems.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { debounceTime, map } from 'rxjs';
 import { TwitchService } from 'src/app/shared/services/twitch.service';
@@ -40,11 +40,10 @@ export class RedeemsComponent {
     }),
   });
 
-  readonly gptEnabled = toSignal(this.openAIService.enabled$);
+  readonly gptEnabled$ = this.openAIService.enabled$;
   readonly redeems$ = this.twitchService.redeems$;
   readonly redeemOptions$ = this.twitchService.redeems$
     .pipe(
-      takeUntilDestroyed(),
       map(redeems => redeems.map<TTSOption>(r => ({ displayName: r.title, value: r.id }))),
     );
 
@@ -54,7 +53,7 @@ export class RedeemsComponent {
       .subscribe((redeemInfo) => {
         this.redeemInfo.setValue(redeemInfo, { emitEvent: false });
       });
-    
+
     this.redeemInfo.valueChanges
       .pipe(takeUntilDestroyed(), debounceTime(500))
       .subscribe(redeemInfo => {

--- a/src/app/pages/twitch/subs/subs.component.ts
+++ b/src/app/pages/twitch/subs/subs.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
-import { debounceTime, filter } from 'rxjs';
+import { filter } from 'rxjs';
 import { TwitchService } from 'src/app/shared/services/twitch.service';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { InputComponent } from '../../../shared/components/input/input.component';
@@ -62,7 +62,6 @@ export class SubsComponent {
     this.charLimit.valueChanges
       .pipe(
         takeUntilDestroyed(),
-        debounceTime(1000),
         filter(() => this.charLimit.valid),
       )
       .subscribe((charLimit) =>
@@ -70,7 +69,7 @@ export class SubsComponent {
       );
 
     this.giftMessage.valueChanges
-      .pipe(takeUntilDestroyed(), debounceTime(1000))
+      .pipe(takeUntilDestroyed())
       .subscribe((giftMessage) =>
         this.twitchService.updateGiftMessage(giftMessage),
       );

--- a/src/app/pages/vstream/auth/auth.component.ts
+++ b/src/app/pages/vstream/auth/auth.component.ts
@@ -46,11 +46,13 @@ export class AuthComponent {
 
         this.isTokenValid.set(false);
       });
+
     /**
      * Each time a user wants to auth we need to do PKCE auth generation.
      * Hence the get method here.
      */
     this.vStreamService.getLoginURL()
+      .pipe(takeUntilDestroyed())
       .subscribe(url => this.loginUrl = url);
   }
 

--- a/src/app/pages/vstream/followers/followers.component.ts
+++ b/src/app/pages/vstream/followers/followers.component.ts
@@ -37,6 +37,7 @@ export class FollowersComponent {
       });
 
     this.settings.valueChanges
+      .pipe(takeUntilDestroyed())
       .subscribe(settings => {
         this.vstreamService.updateCustomMessageSettings(settings, 'follower');
       });

--- a/src/app/pages/vstream/meteor-shower/meteor-shower.component.ts
+++ b/src/app/pages/vstream/meteor-shower/meteor-shower.component.ts
@@ -21,7 +21,7 @@ import { VStreamEventVariables } from '../utils/variables';
 })
 export class MeteorShowerComponent {
   private readonly vstreamService = inject(VStreamService);
-  
+
   readonly variables: VariableTableOption[] = VStreamEventVariables.shower_received.variables;
   readonly settings = new FormGroup({
     enabled: new FormControl(false, { nonNullable: true }),
@@ -38,6 +38,7 @@ export class MeteorShowerComponent {
       });
 
     this.settings.valueChanges
+      .pipe(takeUntilDestroyed())
       .subscribe(settings => {
         this.vstreamService.updateCustomMessageSettings(settings, 'meteor');
       });

--- a/src/app/pages/vstream/overlays/edit-widget/edit-widget.component.html
+++ b/src/app/pages/vstream/overlays/edit-widget/edit-widget.component.html
@@ -33,7 +33,11 @@
             <app-label-block>
               <div header>Trigger event</div>
               <div sub-text>Which event to listen to for this widget.</div>
-              <app-selector [control]="settings.controls.trigger" [options]="eventOptions" placeholder="Select an event" />
+              <app-selector
+                [control]="settings.controls.trigger"
+                [options]="eventOptions"
+                placeholder="Select an event"
+              />
             </app-label-block>
 
             <app-label-block>
@@ -106,7 +110,8 @@
 
             <app-label-block>
               <div header>Font Color</div>
-              <color-chrome [color]="fontColor" (onChange)="changeColor($event)"/>
+              <div sub-text>Color of your font.</div>
+              <input [value]="fontColor" (change)="onColorChange($event)" type="color"/>
             </app-label-block>
 
             <app-variable-table [variables]="variables.variables">

--- a/src/app/pages/vstream/settings/settings.component.ts
+++ b/src/app/pages/vstream/settings/settings.component.ts
@@ -30,7 +30,7 @@ export class SettingsComponent {
       });
 
     this.randomChance.valueChanges
-      .pipe(filter(() => this.randomChance.valid))
+      .pipe(filter(() => this.randomChance.valid), takeUntilDestroyed())
       .subscribe(randomChance => this.vstreamService.updateSettings({ randomChance }));
   }
 }

--- a/src/app/pages/vstream/subscription/subscription.component.ts
+++ b/src/app/pages/vstream/subscription/subscription.component.ts
@@ -47,11 +47,13 @@ export class SubscriptionComponent {
       });
 
     this.renewSettings.valueChanges
+      .pipe(takeUntilDestroyed())
       .subscribe(settings => {
         this.vstreamService.updateCustomMessageSettings(settings, 'sub-renew');
       });
 
     this.giftedSettings.valueChanges
+      .pipe(takeUntilDestroyed())
       .subscribe(settings => {
         this.vstreamService.updateCustomMessageSettings(settings, 'sub-gifted');
       });

--- a/src/app/pages/vstream/uplifts/uplifts.component.ts
+++ b/src/app/pages/vstream/uplifts/uplifts.component.ts
@@ -37,6 +37,7 @@ export class UpliftsComponent {
       });
 
     this.settings.valueChanges
+      .pipe(takeUntilDestroyed())
       .subscribe(settings => {
         this.vstreamService.updateCustomMessageSettings(settings, 'uplift');
       });

--- a/src/app/shared/api/eleven-labs/eleven-labs.api.ts
+++ b/src/app/shared/api/eleven-labs/eleven-labs.api.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { ElevenLabsModel, ElevenLabsVoice } from './eleven-labs.interface';
 import { Store } from '@ngrx/store';
 import { ElevenLabsFeature } from '../../state/eleven-labs/eleven-labs.feature';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Injectable({
   providedIn: 'root',
@@ -15,6 +16,7 @@ export class ElevenLabsApi {
 
   constructor() {
     this.store.select(ElevenLabsFeature.selectApiKey)
+      .pipe(takeUntilDestroyed())
       .subscribe(apiKey => this.apiKey = apiKey);
   }
 

--- a/src/app/shared/api/vstream/vstream.api.ts
+++ b/src/app/shared/api/vstream/vstream.api.ts
@@ -85,17 +85,6 @@ export class VStreamApi {
     });
   }
 
-  getUsersChannelId(username: string, token: string) {
-    const url = `${this.url}/channels/lookup?username=${username}`;
-    const headers = new HttpHeaders({
-      Authorization: `Bearer ${token}`,
-    });
-
-    return this.http.get<{ data: { id: VStreamChannelID } }>(url, {
-      headers,
-    });
-  }
-
   authenticatePubSub(token: string) {
     const url = `${this.url}/events/connect`;
     const headers = new HttpHeaders({

--- a/src/app/shared/components/audio-list/audio-list.component.ts
+++ b/src/app/shared/components/audio-list/audio-list.component.ts
@@ -1,5 +1,4 @@
-import { Component, DestroyRef, inject, Input } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, inject, Input } from '@angular/core';
 import { AsyncPipe, NgClass, NgFor, NgIf } from '@angular/common';
 import { AudioItemComponent } from '../audio-item/audio-item.component';
 import { map } from 'rxjs';
@@ -18,17 +17,14 @@ export class AudioListComponent {
   @Input() filters?: AudioStatus[];
 
   private readonly audioService = inject(AudioService);
-  private readonly destroyRef = inject(DestroyRef);
   protected readonly AudioState = AudioStatus;
 
   readonly audioItems$ = this.audioService.audioItems$
     .pipe(
-      takeUntilDestroyed(this.destroyRef),
       map(items => items.filter(i => this.filters?.length ? this.filters.includes(i.state) : true)),
     );
   readonly currentlyPlaying$ = this.audioService.audioItems$
     .pipe(
-      takeUntilDestroyed(this.destroyRef),
       map(items => items.find(i => i.state === AudioStatus.playing)),
     );
 }

--- a/src/app/shared/components/button/button.component.ts
+++ b/src/app/shared/components/button/button.component.ts
@@ -11,7 +11,6 @@ export type ButtonStyles = 'primary' | 'active' | 'outline' | 'danger';
   imports: [NgClass],
 })
 export class ButtonComponent {
-  @Input() text = '[NONE]';
   @Input() disabled = false;
   @Input() size = 'md';
   @Input() style: ButtonStyles = 'primary';

--- a/src/app/shared/components/input/input.component.ts
+++ b/src/app/shared/components/input/input.component.ts
@@ -13,5 +13,5 @@ export class InputComponent<TKey extends string | number> {
   @Input() placeholder = 'Put something here...';
   @Input({ required: true }) control!: FormControl<TKey>;
   @Input({ required: true }) type!: TKey extends string ? 'text' | 'password' : TKey extends number ? 'number' : never;
-  @Input() hasError: boolean = false;
+  @Input() hasError = false;
 }

--- a/src/app/shared/components/nav/nav.component.ts
+++ b/src/app/shared/components/nav/nav.component.ts
@@ -1,5 +1,5 @@
 import { BreakpointObserver } from '@angular/cdk/layout';
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { SidenavComponent } from '../sidenav/sidenav.component';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatIconModule } from '@angular/material/icon';
@@ -8,6 +8,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { AsyncPipe, NgClass, NgIf } from '@angular/common';
 import { ButtonComponent } from '../button/button.component';
 import { PlaybackService } from '../../services/playback.service';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-nav',
@@ -29,13 +30,16 @@ import { PlaybackService } from '../../services/playback.service';
 export class NavComponent implements OnInit {
   private readonly breakpoint = inject(BreakpointObserver);
   private readonly playbackService = inject(PlaybackService);
+  private readonly destroyRef = inject(DestroyRef);
   readonly isPaused$ = this.playbackService.isPaused$;
   isMobile = false;
 
   ngOnInit(): void {
-    this.breakpoint.observe(['(max-width: 900px)']).subscribe((state) => {
-      this.isMobile = state.matches;
-    });
+    this.breakpoint.observe(['(max-width: 900px)'])
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((state) => {
+        this.isMobile = state.matches;
+      });
   }
 
   unpause() {

--- a/src/app/shared/components/sidenav/changelog-dialog/changelog-dialog.component.ts
+++ b/src/app/shared/components/sidenav/changelog-dialog/changelog-dialog.component.ts
@@ -1,8 +1,9 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { ButtonComponent } from '../../button/button.component';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-changelog-dialog',
@@ -15,6 +16,8 @@ export class ChangelogDialogComponent implements OnInit {
   public readonly dialogRef = inject(MatDialogRef<ChangelogDialogComponent>);
   private readonly http = inject(HttpClient);
   private readonly data = inject(MAT_DIALOG_DATA);
+  private readonly destroyRef = inject(DestroyRef);
+
   // Not sure how I want to handle uploading changelogs, this will be my solution for now.
   readonly changelogUrl = 'https://tts-helper.s3.us-east-2.amazonaws.com/changelog';
   header = 'Loading version changelog...';
@@ -33,6 +36,7 @@ export class ChangelogDialogComponent implements OnInit {
     }>(`${this.changelogUrl}/${version}.json`, {
       headers,
     })
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((data) => {
         this.header = data.headers;
         this.bulletPoints = data.bulletPoints;

--- a/src/app/shared/services/audio.service.ts
+++ b/src/app/shared/services/audio.service.ts
@@ -26,9 +26,7 @@ import { ElevenLabsService } from './eleven-labs.service';
 import { TwitchSettingsState } from '../state/twitch/twitch.feature';
 import { TwitchService } from './twitch.service';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class AudioService {
   private readonly store = inject(Store);
   private readonly configService = inject(ConfigService);

--- a/src/app/shared/services/azure-stt.service.ts
+++ b/src/app/shared/services/azure-stt.service.ts
@@ -18,9 +18,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { OpenAIService } from './openai.service';
 import { TwitchService } from './twitch.service';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class AzureSttService {
   private readonly store = inject(Store);
   private readonly openaiService = inject(OpenAIService);

--- a/src/app/shared/services/chat.service.ts
+++ b/src/app/shared/services/chat.service.ts
@@ -8,9 +8,7 @@ import { AudioService } from './audio.service';
 import { AudioSource } from '../state/audio/audio.feature';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class ChatService {
   generalChat!: GeneralChatState;
   openAIChat!: GptChatState;

--- a/src/app/shared/services/command.service.ts
+++ b/src/app/shared/services/command.service.ts
@@ -8,9 +8,7 @@ import { ChatService } from './chat.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AudioService } from './audio.service';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class CommandService {
   private readonly vstreamService = inject(VStreamService);
   private readonly chatService = inject(ChatService);

--- a/src/app/shared/services/config.service.ts
+++ b/src/app/shared/services/config.service.ts
@@ -11,9 +11,7 @@ import { GlobalConfigActions } from '../state/config/config.actions';
 import { PlaybackService } from './playback.service';
 import { ChatPermissions } from './chat.interface';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class ConfigService {
   private readonly store = inject(Store);
   private readonly playbackService = inject(PlaybackService);

--- a/src/app/shared/services/eleven-labs.service.ts
+++ b/src/app/shared/services/eleven-labs.service.ts
@@ -6,9 +6,7 @@ import { ElevenLabsApi } from '../api/eleven-labs/eleven-labs.api';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { switchMap } from 'rxjs';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class ElevenLabsService {
   private readonly store = inject(Store);
   private readonly elevenLabsApi = inject(ElevenLabsApi);

--- a/src/app/shared/services/logs.service.ts
+++ b/src/app/shared/services/logs.service.ts
@@ -2,12 +2,9 @@
 import { BehaviorSubject } from 'rxjs';
 import { IUserLog, LogLevel } from '../../pages/user-logs/user-logs.interface';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class LogService {
-  filename = 'tts-helper-logs.json' as const;
-  logs$ = new BehaviorSubject<IUserLog[]>([]);
+  readonly logs$ = new BehaviorSubject<IUserLog[]>([]);
 
   add(message: string, level: LogLevel, origin: string) {
     this.logs$.next([

--- a/src/app/shared/services/obs-websocket.service.ts
+++ b/src/app/shared/services/obs-websocket.service.ts
@@ -1,4 +1,4 @@
-﻿import { Injectable } from '@angular/core';
+﻿import { inject, Injectable } from '@angular/core';
 import { PlaybackService } from './playback.service';
 import { AudioService } from './audio.service';
 import { webSocket } from 'rxjs/webSocket';
@@ -13,19 +13,17 @@ type ObsEvent = {
   text?: string;
 };
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class ObsWebSocketService {
+  private readonly playbackService = inject(PlaybackService);
+  private readonly audioService = inject(AudioService);
+  private readonly logService = inject(LogService);
+
   private readonly connection = 'ws://localhost:37891';
   private socket$ = webSocket(this.connection);
   private audioItems: AudioItem[] = [];
 
-  constructor(
-    private readonly playbackService: PlaybackService,
-    private readonly audioService: AudioService,
-    private readonly logService: LogService,
-  ) {
+  constructor() {
     this.audioService.audioItems$
       .pipe(takeUntilDestroyed())
       .subscribe(audioItems => this.audioItems = audioItems);

--- a/src/app/shared/services/openai.service.ts
+++ b/src/app/shared/services/openai.service.ts
@@ -9,9 +9,7 @@ import { GptChatState, GptPersonalityState, GptSettingsState, OpenAIFeature } fr
 import { OpenAIActions } from '../state/openai/openai.actions';
 import { ChatPermissions } from './chat.interface';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class OpenAIService {
   private readonly store = inject(Store);
   private readonly audioService = inject(AudioService);

--- a/src/app/shared/services/playback.service.ts
+++ b/src/app/shared/services/playback.service.ts
@@ -16,9 +16,7 @@ import { Store } from '@ngrx/store';
 import { AudioActions } from '../state/audio/audio.actions';
 import { AudioStatus } from '../state/audio/audio.feature';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class PlaybackService {
   private readonly store = inject(Store);
   private readonly ref = inject(ApplicationRef);

--- a/src/app/shared/services/storage.service.ts
+++ b/src/app/shared/services/storage.service.ts
@@ -2,12 +2,8 @@ import { Injectable } from '@angular/core';
 import { from, Observable } from 'rxjs';
 import { Store } from 'tauri-plugin-store-api';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class StorageService {
-  constructor() {}
-
   async saveToStore<T>(file: string, key: string, data: T) {
     const store = new Store(file);
 

--- a/src/app/shared/services/twitch-pubsub.ts
+++ b/src/app/shared/services/twitch-pubsub.ts
@@ -15,9 +15,7 @@ import { GptSettingsState } from '../state/openai/openai.feature';
 import { TwitchSettingsState } from '../state/twitch/twitch.feature';
 import { ChatService } from './chat.service';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class TwitchPubSub implements OnDestroy {
   private readonly twitchService = inject(TwitchService);
   private readonly audioService = inject(AudioService);

--- a/src/app/shared/services/vtubestudio.service.ts
+++ b/src/app/shared/services/vtubestudio.service.ts
@@ -16,9 +16,7 @@ import { VTubeStudioFeature, VTubeStudioState } from '../state/vtubestudio/vtube
 import { VTubeStudioActions } from '../state/vtubestudio/vtubestudio.actions';
 import { BehaviorSubject, interval } from 'rxjs';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class VTubeStudioService {
   private readonly store = inject(Store);
   private readonly logService = inject(LogService);
@@ -121,19 +119,6 @@ export class VTubeStudioService {
     this.playbackService.audioSkipped$
       .pipe(takeUntilDestroyed())
       .subscribe(() => this.randomMouth(false));
-
-
-    /**
-     * @TODO - Use the Rust tick alternative solution.
-     * This is a temporary hack. Due to the memory issues caused by unused references from intervals
-     * this will be the watchman killing the 60ms interval used for tracking users mouth data.
-     */
-    interval(3_600_000)
-      .subscribe(() => {
-        clearInterval(this.mouthTrackingInterval);
-
-        this.mouthTrackingInterval = this.createMouthTrackingInterval();
-      });
   }
 
   private get isTracking() {

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>TTS Helper</title>
+    <title>TTS Helper Angular</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,23 @@ import { ElevenLabsFeature } from './app/shared/state/eleven-labs/eleven-labs.fe
 import { VTubeStudioFeature } from './app/shared/state/vtubestudio/vtubestudio.feature.';
 import { OpenAIFeature } from './app/shared/state/openai/openai.feature';
 import { VStreamFeature } from './app/shared/state/vstream/vstream.feature';
+import { AzureSttService } from './app/shared/services/azure-stt.service';
+import { AudioService } from './app/shared/services/audio.service';
+import { ChatService } from './app/shared/services/chat.service';
+import { CommandService } from './app/shared/services/command.service';
+import { ElevenLabsService } from './app/shared/services/eleven-labs.service';
+import { ConfigService } from './app/shared/services/config.service';
+import { LogService } from './app/shared/services/logs.service';
+import { OpenAIService } from './app/shared/services/openai.service';
+import { ObsWebSocketService } from './app/shared/services/obs-websocket.service';
+import { StreamDeckWebSocketService } from './app/shared/services/streamdeck-websocket.service';
+import { PlaybackService } from './app/shared/services/playback.service';
+import { StorageService } from './app/shared/services/storage.service';
+import { TwitchPubSub } from './app/shared/services/twitch-pubsub';
+import { TwitchService } from './app/shared/services/twitch.service';
+import { VStreamService } from './app/shared/services/vstream.service';
+import { VStreamPubSubService } from './app/shared/services/vstream-pubsub.service';
+import { VTubeStudioService } from './app/shared/services/vtubestudio.service';
 
 bootstrapApplication(AppComponent, {
   providers: [
@@ -38,6 +55,23 @@ bootstrapApplication(AppComponent, {
     provideHttpClient(withInterceptorsFromDi()),
     provideAnimations(),
     provideRouter(routes),
+    AzureSttService,
+    AudioService,
+    ChatService,
+    CommandService,
+    ElevenLabsService,
+    ConfigService,
+    LogService,
+    OpenAIService,
+    ObsWebSocketService,
+    StreamDeckWebSocketService,
+    PlaybackService,
+    StorageService,
+    TwitchPubSub,
+    TwitchService,
+    VStreamService,
+    VStreamPubSubService,
+    VTubeStudioService,
   ],
 })
   .catch((err) => console.error(err));


### PR DESCRIPTION
This PR fixes some crucial memory leaks.

* Removes the update checker in favor of just launching the dialog on app launch if there is an update. The update checker _for some reason_ was causing a horrible buildup of memory issues in WebView2. There may be an issue with JS -> Rust communication via Tauri API functions.
* Remove the ngx-color picker from VStream, since it appeared in all widgets. It _for some reason???_ was causing MAJOR memory issues whenever they were rendered. I still cannot figure out why they do, but they're removed. Todo: Remove ngx-color completely.
* Implement all missing `takeUntilDestroyed` methods in all components and services.